### PR TITLE
Automated cherry pick of #56: fix: debian config maridb need python-pymysql

### DIFF
--- a/onecloud/roles/mariadb/tasks/main.yml
+++ b/onecloud/roles/mariadb/tasks/main.yml
@@ -16,9 +16,11 @@
     ansible_python_interpreter: "{{ ansible_facts.python.executable }}"
   when: ansible_python_interpreter is not defined
 
-- name: Install mariadb
+- name: Install mariadb python libs
   package:
-    name: python-mysqldb
+    name:
+    - python-mysqldb
+    - python-pymysql
     state: present
   when: ansible_os_family == "Uniontech OS Server 20 Enterprise" or ansible_os_family == "Debian"
 


### PR DESCRIPTION
Cherry pick of #56 on release/3.6.

#56: fix: debian config maridb need python-pymysql