### PR TITLE
Automated cherry pick of #62: fix: centos qemu rpm package missing

### DIFF
--- a/onecloud/roles/common/vars/centos-x86_64.yml
+++ b/onecloud/roles/common/vars/centos-x86_64.yml
@@ -54,3 +54,4 @@ common_packages:
   - yunion-executor
   - yunion-ocadm
   - yunion-ovmfrpm
+  - yunion-qemu-2.12.1


### PR DESCRIPTION
Cherry pick of #62 on release/3.6.

#62: fix: centos qemu rpm package missing