### PR TITLE
fix: search for the correct line from ip route

### DIFF
--- a/onecloud/roles/primary-master-node/setup_cloud/tasks/main.yml
+++ b/onecloud/roles/primary-master-node/setup_cloud/tasks/main.yml
@@ -15,7 +15,7 @@
     default_ip: "{{ default_ip_ret.stdout }}"
 
 - name: "Get default ip address {{ default_ip }} masklen"
-  shell: "ip route list | grep {{ default_ip }} | head -n 1 | awk '{print $1}' | cut -d '/' -f 2"
+  shell: "ip route list | grep -w {{ default_ip }} | head -n 1 | awk '{print $1}' | cut -d '/' -f 2"
   register: default_masklen_ret
 
 - name: Set default ip masklen


### PR DESCRIPTION
example:
```
default via 192.168.121.254 dev br0
192.169.121.0/24 dev br0 proto kernel scope link src 192.168.121.25
```

The command "grep 192.168.121.25" cannot filter out the correct line.
Just add the'-w' parameter to grep and it works.