### PR TITLE
fix(docker,deploy): 去掉 docker version 的字符串;使用 repo 默认的版本安装

### DIFF
--- a/onecloud/roles/common/tasks/main.yml
+++ b/onecloud/roles/common/tasks/main.yml
@@ -208,8 +208,8 @@
   - name: Install docker
     yum:
       name:
-        - docker-ce-19.03.9
-        - docker-ce-cli-19.03.9
+        - docker-ce
+        - docker-ce-cli
         - containerd.io
     when:
     - is_centos_x86 is defined


### PR DESCRIPTION
## 这个 PR 实现什么功能/修复什么问题:

* 去掉 docker version 的字符串;使用 repo 默认的版本安装

## 是否需要 backport 到之前的 release 分支:

* release/3.7
* release/3.6
