### PR TITLE
Automated cherry pick of #96: fix: reboot node if centos kernel is not yn version

### DIFF
--- a/onecloud/roles/master-node/tasks/main.yml
+++ b/onecloud/roles/master-node/tasks/main.yml
@@ -13,6 +13,13 @@
   include_role:
     name: tcp
 
+- name: Include utils/kernel-check tasks
+  include_role:
+    name: utils/kernel-check
+  when:
+  - k8s_node_as_oc_host|default(false)|bool == true
+  - is_centos_x86 is defined
+
 - name: Include utils/controlplane tasks
   include_role:
     name: utils/controlplane

--- a/onecloud/roles/primary-master-node/setup_k8s/tasks/main.yml
+++ b/onecloud/roles/primary-master-node/setup_k8s/tasks/main.yml
@@ -6,6 +6,13 @@
   include_role:
     name: tcp
 
+- name: Include utils/kernel-check tasks
+  include_role:
+    name: utils/kernel-check
+  when:
+  - k8s_node_as_oc_host|default(false)|bool == true
+  - is_centos_x86 is defined
+
 - name: Include utils/controlplane tasks
   include_role:
     name: utils/controlplane

--- a/onecloud/roles/utils/kernel-check/tasks/main.yml
+++ b/onecloud/roles/utils/kernel-check/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: Define kernel regex
+  set_fact: kernel_regex="el[0-9]+.yn[0-9]{8}."
+
+- name: Is yunion kernel running
+  shell: |
+    uname -r | grep -E "{{ kernel_regex }}"
+  register: is_yunion_kernel_running
+  changed_when: false
+  failed_when: false
+  args:
+    warn: no
+
+- name: Is yunion kernel installed
+  shell: |
+    count=$(rpm -qa |grep kernel |grep -E "{{ kernel_regex }}" |wc -l)
+    [[ "$count" -ge 3 ]]
+  register: is_yunion_kernel_installed
+  changed_when: false
+  failed_when: false
+  args:
+    warn: no
+
+- name: Reboot system if not yunion kernel, it should take a few minutes...
+  reboot:
+    reboot_timeout:  900  # 15 mins
+    connect_timeout: 900 # 15 mins
+    msg: "rebooting host to enable yunion kernel ... please wait... "
+    test_command: "uname -r | grep -qE '{{ kernel_regex }}'   "
+  when: is_yunion_kernel_running.rc != 0

--- a/onecloud/roles/worker-node/tasks/main.yml
+++ b/onecloud/roles/worker-node/tasks/main.yml
@@ -22,6 +22,13 @@
   when:
     k8s_node_as_oc_controller|default(false)|bool == true
 
+- name: Include utils/kernel-check tasks
+  include_role:
+    name: utils/kernel-check
+  when:
+  - k8s_node_as_oc_host|default(false)|bool == true
+  - is_centos_x86 is defined
+
 - name: construct k8s_controlplane_host
   set_fact:
     k8s_controlplane_host: "{{groups['primary_master_node'][0]}}"


### PR DESCRIPTION
Cherry pick of #96 on release/3.7.

#96: fix: reboot node if centos kernel is not yn version