### PR TITLE
Automated cherry pick of #104: fix(deploy,reboot): 在外部的python里检测是否需要重启。重启条件：本机执行 primary 安装时，python 脚本负责重启；远程 ssh 安装primary时，ansible 负责重启.

### DIFF
--- a/lib/install.py
+++ b/lib/install.py
@@ -2,10 +2,12 @@
 import argparse
 import sys
 import os
+import time
 
 from . import ocboot
 from . import cmd
 from . import logger
+from . import kernel_utils
 
 logger = logger.new(__file__)
 
@@ -24,6 +26,17 @@ User: %s
 Password: %s
 """
 
+REBOOT_MSG = """
+┌───────────────────────────────────────────────────────────────────────────────┐
+│                                                                               │
+│   The system is about to reboot in 30 secs to use new kernel.                 │
+│   You may abort the reboot by press Ctrl + C, and manually reboot later.      │
+│                                                                               │
+└───────────────────────────────────────────────────────────────────────────────┘
+
+"""
+
+REBOOT_TIMEOUT = 30
 
 def add_command(subparsers):
     parser = subparsers.add_parser("install", help="install onecloud cluster")
@@ -39,9 +52,25 @@ def do_install(args):
     except Exception as e:
         raise e
 
+def try_reboot_primary(ip):
+    if not ip:
+        return
+    if not kernel_utils.is_local_ip(ip):
+        return
+    if kernel_utils.is_yunion_kernel():
+        return
+
+    print(REBOOT_MSG)
+
+    for i in range(REBOOT_TIMEOUT):
+        time.sleep(1)
+        print("."),
+    os.system('reboot')
+
 
 def start(config_file):
     config = ocboot.load_config(config_file)
+
     inventory_f = config.generate_inventory_file()
 
     return_code = cmd.run_ansible_playbook(
@@ -61,4 +90,7 @@ def start(config_file):
         print(CE_INSTALLED_STR % (login_info[0],
                                   login_info[1],
                                   login_info[2]))
+
+    try_reboot_primary(config.primary_master_config.node.node_ip)
+
     return 0

--- a/lib/kernel_utils.py
+++ b/lib/kernel_utils.py
@@ -1,0 +1,32 @@
+import re
+import socket
+import fcntl
+import struct
+import os
+import platform
+
+
+def get_ip_address(ifname):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    inet = fcntl.ioctl(s.fileno(), 0x8915, struct.pack('256s', ifname[:15]))
+    ret = socket.inet_ntoa(inet[20:24])
+    return ret
+
+
+def get_all_ips():
+    ips = []
+    for interface in os.listdir('/sys/class/net/'):
+        try:
+            ip = get_ip_address(interface)
+            ips.append(ip)
+        except Exception:
+            pass
+    return ips
+
+def is_local_ip(ip):
+    return ip in get_all_ips()
+
+def is_yunion_kernel():
+    kernel_str = platform.platform()
+    pattern = re.compile(r'\.yn[\d]{8}\.')
+    return pattern.search(kernel_str) is not None

--- a/onecloud/install-cluster.yml
+++ b/onecloud/install-cluster.yml
@@ -21,3 +21,7 @@
 - hosts: worker_nodes
   roles:
     - worker-node
+
+- hosts: primary_master_node
+  roles:
+    - primary-master-node/reboot

--- a/onecloud/roles/utils/kernel-check/tasks/main.yml
+++ b/onecloud/roles/utils/kernel-check/tasks/main.yml
@@ -23,8 +23,10 @@
 
 - name: Reboot system if not yunion kernel, it should take a few minutes...
   reboot:
-    reboot_timeout:  900  # 15 mins
+    reboot_timeout:  900 # 15 mins
     connect_timeout: 900 # 15 mins
     msg: "rebooting host to enable yunion kernel ... please wait... "
     test_command: "uname -r | grep -qE '{{ kernel_regex }}'   "
-  when: is_yunion_kernel_running.rc != 0
+  when:
+  - is_yunion_kernel_running.rc != 0
+  - ansible_connection == "ssh"


### PR DESCRIPTION
Cherry pick of #104 on release/3.7.

#104: fix(deploy,reboot): 在外部的python里检测是否需要重启。重启条件：本机执行 primary 安装时，python 脚本负责重启；远程 ssh 安装primary时，ansible 负责重启.