### PR TITLE
hotfix(db,port):解决临时密码安装的 bug，解决端口检测的 bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ onecloud/site.yml
 onecloud/zz_generated.*
 #onecloud/ansible.cfg
 #onecloud/callback_plugins
+config-allinone-current.yml

--- a/lib/upgrade.py
+++ b/lib/upgrade.py
@@ -18,7 +18,7 @@ A_OCBOOT_UPGRADE_CURRENT_VERSION = 'upgrade.ocboot.yunion.io/current-version'
 UPGRADE_MSG = """
 ┌───────────────────────────────────────────────────────────────────────────────┐
 │                                                                               │
-│   The system has been upgraded to the latest version.                      │
+│      The system has been upgraded to the latest version.                      │
 │                                                                               │
 └───────────────────────────────────────────────────────────────────────────────┘
 

--- a/onecloud/roles/utils/port-check/tasks/main.yml
+++ b/onecloud/roles/utils/port-check/tasks/main.yml
@@ -4,10 +4,10 @@
   wait_for:
     port: "{{ item  }}"
     state: stopped
+    timeout: 3
   with_items:
     - 80
     - 443
     - 6443
     - 8080
-  timeout: 3
 

--- a/run.py
+++ b/run.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import re
+import yaml
 
 from lib import install
 
@@ -91,6 +92,18 @@ def gen_config(ipaddr):
     verf = os.path.join(cur_path, "VERSION")
     with open(verf, 'r') as f:
         ver = f.read().strip()
+
+    if os.path.exists(temp):
+        with open(temp, 'r') as stream:
+            try:
+                data = (yaml.safe_load(stream))
+                if data.get('primary_master_node', {}).get('hostname', '') == ipaddr and \
+                   data.get('primary_master_node', {}).get('onecloud_version', '') == ver:
+                    print("reuse current yaml: %s" % temp)
+                    return temp
+            except yaml.YAMLError as exc:
+                raise Exception("paring %s error: %s" % (temp, exc))
+
     mypass = random_password(12)
     with open(temp, 'w') as f:
         f.write(conf.replace('10.127.10.158', ipaddr).replace('your-sql-password', mypass).replace('v3.4.12', ver))


### PR DESCRIPTION
## 这个 PR 实现什么功能/修复什么问题:

* 解决临时密码安装的 bug，如果 db 密码能登录则保持原流程；如果密码无法登录则备份数据库并重装
* 解决端口检测的 bug

## 是否需要 backport 到之前的 release 分支:

* release/3.7
