### PR TITLE
fix(reboot,deploy,k8s): 重构重启逻辑

### DIFF
--- a/onecloud/roles/utils/kernel-check/tasks/main.yml
+++ b/onecloud/roles/utils/kernel-check/tasks/main.yml
@@ -30,3 +30,4 @@
   when:
   - is_yunion_kernel_running.rc != 0
   - ansible_connection == "ssh"
+  - no_reboot is not defined or no_reboot|default(false)|bool == false


### PR DESCRIPTION
## 这个 PR 实现什么功能/修复什么问题:

* 重构重启逻辑; 由 ocboot 根据当前 python 脚本环境的 ip 与 ansible-playbook 的 IP 做对比；
* 如果两者不同，则认为ocboot 与playbook 不在同一机器；此时由playbook 负责重启，由 ocboot 进行重启的等待；
* 如果两者相同，则认为ocboot 与playbook 处于同一机器；此时ansible 忽略重启步骤，由 ocboot 负责重启，重启之前打印 login 信息，并等待30秒，然后重启。

## 是否需要 backport 到之前的 release 分支:

* release/3.7
