### PR TITLE
fix(deploy,ocboot,reboot): 解决 ocboot 远程 ssh 执行安装时,错误地重启 ocboot 本机的 bug

### DIFF
--- a/lib/install.py
+++ b/lib/install.py
@@ -58,7 +58,9 @@ def need_reboot(ip, inside):
         return False
     if not ip:
         return False
-    if kernel_utils.is_local_ip(ip) and inside == True:
+    if (inside is False) and (not kernel_utils.is_local_ip(ip)):
+        return False
+    if kernel_utils.is_local_ip(ip) and inside is True:
         return False
     if kernel_utils.is_yunion_kernel():
         return False


### PR DESCRIPTION
## 这个 PR 实现什么功能/修复什么问题:

* 解决 ocboot 远程 ssh 执行安装时,错误地重启 ocboot 本机的 bug

## 是否需要 backport 到之前的 release 分支:

* release/3.7
