### PR TITLE
Automated cherry pick of #156: fix(deploy,ocboot,reboot): 解决 ocboot 远程 ssh 执行安装时,错误地重启 ocboot 本机的 bug

### DIFF
--- a/lib/install.py
+++ b/lib/install.py
@@ -58,7 +58,9 @@ def need_reboot(ip, inside):
         return False
     if not ip:
         return False
-    if kernel_utils.is_local_ip(ip) and inside == True:
+    if (inside is False) and (not kernel_utils.is_local_ip(ip)):
+        return False
+    if kernel_utils.is_local_ip(ip) and inside is True:
         return False
     if kernel_utils.is_yunion_kernel():
         return False


### PR DESCRIPTION
Cherry pick of #156 on release/3.7.

#156: fix(deploy,ocboot,reboot): 解决 ocboot 远程 ssh 执行安装时,错误地重启 ocboot 本机的 bug