### PR TITLE
update kernel test regex for kernel 5.x since release/3.8+

### DIFF
--- a/onecloud/roles/utils/kernel-check/tasks/main.yml
+++ b/onecloud/roles/utils/kernel-check/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Define kernel regex
-  set_fact: kernel_regex="el[0-9]+.yn[0-9]{8}."
+  set_fact: kernel_regex="\.yn[0-9]{8}\."
 
 - name: Is yunion kernel running
   shell: |


### PR DESCRIPTION
## 这个 PR 实现什么功能/修复什么问题:

* 3.8 起，更新检测 kernel 5.x 的正则。

## 是否需要 backport 到之前的 release 分支:

* release/3.8