### PR TITLE
Automated cherry pick of #241: fix(kernel,lsmod): 5.x 内核不再进行 lsmod 内核模块校验，以免报错

### DIFF
--- a/onecloud/roles/common/tasks/main.yml
+++ b/onecloud/roles/common/tasks/main.yml
@@ -112,15 +112,6 @@
   - br_netfilter
   - ip_conntrack
 
-- name: Test ip_conntrack status
-  shell: |
-    set -e
-    set -o pipefail
-    lsmod |grep conntrack
-    lsmod |grep br_netfilter
-  args:
-    executable: /bin/bash
-
 - name: Load br_netfilter at boot
   copy:
     owner: root


### PR DESCRIPTION
Cherry pick of #241 on release/3.8.

#241: fix(kernel,lsmod): 5.x 内核不再进行 lsmod 内核模块校验，以免报错