### PR TITLE
提前安装 ca certs 以防证书过期

### DIFF
--- a/onecloud/roles/common/tasks/main.yml
+++ b/onecloud/roles/common/tasks/main.yml
@@ -8,6 +8,7 @@
     name:
       - bash-completion
       - epel-release
+      - ca-certificates
   when:
   - is_centos_x86 is defined
   - non_iso_mode is defined


### PR DESCRIPTION
## 这个 PR 实现什么功能/修复什么问题:

* 提前安装 ca certs 以防证书过期
 
## 是否需要 backport 到之前的 release 分支:

* release/3.7
* release/3.8