### PR TITLE
Automated cherry pick of #284: fix(grub_setup): find grub2 cfg exists

### DIFF
--- a/onecloud/roles/utils/gpu-init/files/gpu_setup.sh
+++ b/onecloud/roles/utils/gpu-init/files/gpu_setup.sh
@@ -128,7 +128,7 @@ grub_setup() {
     # 以便解决重启后因未加载 lvm 驱动而卡住的问题
     sed -i -e 's#rd.lvm.lv=[^ ]*##gi' $grub_cfg
 
-    idx=$(awk -F\' '$1=="menuentry " {print i++ " : " $2}' $(find /etc/ -name 'grub2*cfg' |head -1 ) |grep -P '\.yn\d{8}\.'|awk '{print $1}' |head -1)
+    idx=$(awk -F\' '$1=="menuentry " {print i++ " : " $2}' $(find /etc/ -name 'grub2*cfg' -exec test -e {} \; -print |head -1 ) |grep -P '\.yn\d{8}\.'|awk '{print $1}' |head -1)
     if grep -q '^GRUB_DEFAULT' $grub_cfg; then
         sudo sed -i -e "s#^GRUB_DEFAULT=.*#GRUB_DEFAULT=$idx#" $grub_cfg
     else


### PR DESCRIPTION
Cherry pick of #284 on release/3.7.

#284: fix(grub_setup): find grub2 cfg exists