### PR TITLE
备份/恢复时,明确忽略掉iso_install_mode变量

### DIFF
--- a/lib/db.py
+++ b/lib/db.py
@@ -154,3 +154,4 @@ def backup_config(src, dest):
     output = os.path.join(dest, 'config.yml')
     print('backup config %s to %s... ' % (src, output))
     copyfile(src, output)
+    run_bash_cmd(""" sed -i -e 's@^  iso_install_mode: true@#  iso_install_mode: true@' '%s' """ % output)

--- a/lib/restore.py
+++ b/lib/restore.py
@@ -212,6 +212,7 @@ def restore_config(args):
             f.write(yaml_content)
         except IOError as e:
             print('write yaml config to %s error: %s!' % (config_file, e))
+    run_bash_cmd(""" sed -i -e 's@^  iso_install_mode: true@#  iso_install_mode: true@' '%s' """ % config_file)
 
 def helper():
     print('\n')


### PR DESCRIPTION
## 这个 PR 实现什么功能/修复什么问题:

* iso_install_mode

## 是否需要 backport 到之前的 release 分支:

* release/3.7
* release/3.8
* release/3.9