### PR TITLE
Automated cherry pick of #343: fix:(deploy,os)显式拒绝centos/uos/debian 之外的 OS release

### DIFF
--- a/onecloud/roles/utils/detect-os/tasks/main.yml
+++ b/onecloud/roles/utils/detect-os/tasks/main.yml
@@ -16,7 +16,6 @@
         - defaults.yml
       paths:
         - ../vars
-      skip: true
   tags:
     - facts
 


### PR DESCRIPTION
Cherry pick of #343 on release/3.9.

#343: fix:(deploy,os)显式拒绝centos/uos/debian 之外的 OS release