### PR TITLE
Automated cherry pick of #361: remove mysql_user and mysql_db steps

### DIFF
--- a/onecloud/roles/mariadb/tasks/main.yml
+++ b/onecloud/roles/mariadb/tasks/main.yml
@@ -85,18 +85,3 @@
     fi
   args:
     executable: /bin/bash
-
-- name: Remove all anonymous user accounts
-  mysql_user:
-    name: ''
-    host_all: yes
-    state: absent
-    login_user: "{{ db_user }}"
-    login_password: "{{ db_password }}"
-
-- name: Remove test database
-  mysql_db:
-    name: test
-    state: absent
-    login_user: "{{ db_user }}"
-    login_password: "{{ db_password }}"


### PR DESCRIPTION
Cherry pick of #361 on release/3.9.

#361: remove mysql_user and mysql_db steps