### PR TITLE
release/3.9 打包流程变更：新增 onecloud-ee 打包 rpm/climc-ee 的步骤；

### DIFF
--- a/onecloud/roles/pre-install-common/tasks/main.yml
+++ b/onecloud/roles/pre-install-common/tasks/main.yml
@@ -76,6 +76,7 @@
     - usbredir
     - wget
     - yunion-climc
+    - yunion-climc-ee
     - yunion-executor
     - yunion-fetcherfs
     - yunion-ocadm

--- a/onecloud/roles/upgrade/common/tasks/v3_8-v3_9.yml
+++ b/onecloud/roles/upgrade/common/tasks/v3_8-v3_9.yml
@@ -37,6 +37,7 @@
     name:
       - yunion-ocadm
       - yunion-climc
+      - yunion-climc-ee
       - yunion-executor
     disablerepo: "*"
     enablerepo: "yunion-*"


### PR DESCRIPTION
## 这个 PR 实现什么功能/修复什么问题:

* 新增 onecloud-ee 打包 rpm/climc-ee 的步骤；

## 是否需要 backport 到之前的 release 分支:

* release/3.9