### PR TITLE
3.9 更改 repo url 路径

### DIFF
--- a/lib/upgrade.py
+++ b/lib/upgrade.py
@@ -106,7 +106,8 @@ class UpgradeConfig(object):
     def get_yunion_yum_repo(self):
         ver = self.upgrade_onecloud_major_version.replace('_', '.')
         ver = ver[1:]
-        return "https://iso.yunion.cn/yumrepo-%s/yunion.repo" % (ver)
+        return "https://iso.yunion.cn/centos/7/%s/x86_64/yunion.repo" % (ver)
+
 
     def to_ansible_vars(self):
         return {

--- a/onecloud/roles/common/tasks/v3_9.yml
+++ b/onecloud/roles/common/tasks/v3_9.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add yunion rpm repository
   get_url:
-    url: https://iso.yunion.cn/yumrepo-3.8/yunion.repo
+    url: https://iso.yunion.cn/centos/7/3.9/x86_64/yunion.repo
     dest: /etc/yum.repos.d/yunion.repo
     validate_certs: no
   become: yes


### PR DESCRIPTION
## 这个 PR 实现什么功能/修复什么问题:

* 3.9 更改 repo url 路径. 目前所做改动只涉及 x86 centos 7。其他发行版 会陆续更新，单独提 pr.

## 是否需要 backport 到之前的 release 分支:

* release/3.9