### PR TITLE
minor: 更新arm kylin qemu version

### DIFF
--- a/d.diff
+++ b/d.diff
@@ -1,0 +1,10 @@
+diff --git a/onecloud/roles/utils/detect-os/vars/kylin_linux_advanced_server-v10.aarch64.yml b/onecloud/roles/utils/detect-os/vars/kylin_linux_advanced_server-v10.aarch64.yml
+index 386817f..b4a27ca 100644
+--- a/onecloud/roles/utils/detect-os/vars/kylin_linux_advanced_server-v10.aarch64.yml
++++ b/onecloud/roles/utils/detect-os/vars/kylin_linux_advanced_server-v10.aarch64.yml
+@@ -66,7 +66,7 @@ common_packages:
+   - yunion-fetcherfs
+   - yunion-ocadm
+   - yunion-ovmfrpm
+-  - yunion-qemu-4.2.0
++  - yunion-qemu-4.2.0-4.2.0-20220406.ky10.ky10

--- a/onecloud/roles/utils/detect-os/vars/kylin_linux_advanced_server-v10.aarch64.yml
+++ b/onecloud/roles/utils/detect-os/vars/kylin_linux_advanced_server-v10.aarch64.yml
@@ -66,7 +66,7 @@ common_packages:
   - yunion-fetcherfs
   - yunion-ocadm
   - yunion-ovmfrpm
-  - yunion-qemu-4.2.0
+  - yunion-qemu-4.2.0-4.2.0-20220406.ky10.ky10
 
 common_services:
     - ntpd


### PR DESCRIPTION
## 这个 PR 实现什么功能/修复什么问题:

* 更新麒麟qemu 版本为 yunion-qemu-4.2.0-4.2.0-20220406.ky10.ky10

## 是否需要 backport 到之前的 release 分支:

* release/3.9