### PR TITLE
zentao/bug-view-8490.html: v3.9 开源版本通过yaml配置文件安装v3.9.1时不应该拉取registry.…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ update-pciids:
 
 .PHONY: test
 
-REGISTRY ?= "registry.cn-beijing.aliyuncs.com/yunionio"
+REGISTRY ?= "registry.cn-beijing.aliyuncs.com/yunion"
 VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
                 git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
 

--- a/lib/ocboot.py
+++ b/lib/ocboot.py
@@ -29,7 +29,7 @@ def get_ansible_global_vars(version):
 
     # set yunion_qemu_package for pre released version
     yunion_qemu_package = 'yunion-qemu-4.2.0'
-    extra_packages = [] 
+    extra_packages = []
     if major_version in ['v3_6', 'v3_7', 'v3_8']:
         yunion_qemu_package = 'yunion-qemu-2.12.1'
     else:
@@ -378,7 +378,7 @@ class PrimaryMasterConfig(OnecloudConfig):
         self.onecloud_user = config.get('onecloud_user', 'admin')
         self.onecloud_user_password = config.get('onecloud_user_password', 'admin@123')
         self.use_ee = config.get('use_ee', False)
-        self.image_repository = config.get('image_repository', 'registry.cn-beijing.aliyuncs.com/yunionio')
+        self.image_repository = config.get('image_repository', 'registry.cn-beijing.aliyuncs.com/yunion')
         self.enable_minio = config.get('enable_minio', False)
         self.offline_nodes = config.get('offline_nodes', '')
         self.pod_network_cidr = config.get('pod_network_cidr', '10.40.0.0/16')

--- a/lib/upgrade.py
+++ b/lib/upgrade.py
@@ -67,7 +67,7 @@ def add_command(subparsers):
 
     parser.add_argument("--image-repository", "-i",
                         dest="image_repository",
-                        default="registry.cn-beijing.aliyuncs.com/yunionio",
+                        default="registry.cn-beijing.aliyuncs.com/yunion",
                         help="specify 3rd party image and namespace")
 
 

--- a/onecloud/roles/primary-master-node/setup_k8s/tasks/main.yml
+++ b/onecloud/roles/primary-master-node/setup_k8s/tasks/main.yml
@@ -15,7 +15,7 @@
   register: K8S_TOKEN
 
 - name: Pull ocadm images on node
-  command: "/opt/yunion/bin/ocadm config images pull --image-repository {{ image_repository | default('registry.cn-beijing.aliyuncs.com/yunionio')}} --onecloud-version {{ onecloud_version | default('latest') }} --operator-version {{ onecloud_version | default('latest') }}"
+  command: "/opt/yunion/bin/ocadm config images pull --image-repository {{ image_repository | default('registry.cn-beijing.aliyuncs.com/yunion')}} --onecloud-version {{ onecloud_version | default('latest') }} --operator-version {{ onecloud_version | default('latest') }}"
   register: command_result
   changed_when: '"Image is up to date" not in command_result.stdout or "Already exists" not in command_result.stdout'
   when:

--- a/onecloud/roles/upgrade/primary_master_node/tasks/main.yml
+++ b/onecloud/roles/upgrade/primary_master_node/tasks/main.yml
@@ -9,7 +9,7 @@
       pkill ocadm
       /opt/yunion/bin/ocadm cluster update --operator-version {{ upgrade_onecloud_version }} \
         --version {{ upgrade_onecloud_version }} \
-        --image-repository {{ image_repository | default('registry.cn-beijing.aliyuncs.com/yunionio')}} \
+        --image-repository {{ image_repository | default('registry.cn-beijing.aliyuncs.com/yunion')}} \
         --wait
   # 30 minutes timeout
   async: 1800


### PR DESCRIPTION
## 这个 PR 实现什么功能/修复什么问题:

*  v3.9 开源版本通过yaml配置文件安装v3.9.1时不应该拉取registry.cn-beijing.aliyuncs.com/yunionio仓库的镜像

## 是否需要 backport 到之前的 release 分支:

* release/3.9