### PR TITLE
Automated cherry pick of #445: 去掉对epel 的依赖；将所需的rpm 纳入yunion源

### DIFF
--- a/onecloud/roles/pre-install-common/tasks/main.yml
+++ b/onecloud/roles/pre-install-common/tasks/main.yml
@@ -46,7 +46,6 @@
     - containerd.io
     - cri-tools
     - docker-ce
-    - epel-release
     - fuse
     - fuse-devel
     - fuse-libs

--- a/onecloud/roles/utils/detect-os/vars/centos-aarch64.yml
+++ b/onecloud/roles/utils/detect-os/vars/centos-aarch64.yml
@@ -13,7 +13,6 @@ common_packages:
   - ca-certificates
   - celt051
   - conntrack-tools
-  - epel-release
   - fuse
   - fuse-devel
   - fuse-libs

--- a/onecloud/roles/utils/detect-os/vars/centos-x86_64.yml
+++ b/onecloud/roles/utils/detect-os/vars/centos-x86_64.yml
@@ -15,7 +15,6 @@ common_packages:
   - celt051
   - conntrack-tools
   - curl
-  - epel-release
   - fuse
   - fuse-devel
   - fuse-libs


### PR DESCRIPTION
Cherry pick of #445 on release/3.9.

#445: 去掉对epel 的依赖；将所需的rpm 纳入yunion源