### PR TITLE
v3.9.0 去掉 rpm包 iscsi-initiator-utils

### DIFF
--- a/onecloud/roles/pre-install-common/tasks/main.yml
+++ b/onecloud/roles/pre-install-common/tasks/main.yml
@@ -51,7 +51,6 @@
     - fuse-libs
     - htop
     - ipvsadm
-    - iscsi-initiator-utils
     - jq
     - kmod-openvswitch
     - kubeadm-1.15.12-0


### PR DESCRIPTION
- iscsi-initiator-utils 是 longhorn 相关依赖，已经不再需要

cherry pick:
- release/3.9