### PR TITLE
Automated cherry pick of #478: fix(helm): nginx ingress annotations for HTTPS

### DIFF
--- a/charts/cloudpods/values-dev.yaml
+++ b/charts/cloudpods/values-dev.yaml
@@ -199,7 +199,8 @@ cluster:
 ingress:
   enabled: true
   className: ""
-  annotations: {}
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:

--- a/charts/cloudpods/values-prod.yaml
+++ b/charts/cloudpods/values-prod.yaml
@@ -212,7 +212,8 @@ cluster:
 ingress:
   enabled: true
   className: ""
-  annotations: {}
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:

--- a/charts/cloudpods/values.yaml
+++ b/charts/cloudpods/values.yaml
@@ -199,7 +199,8 @@ cluster:
 ingress:
   enabled: true
   className: ""
-  annotations: {}
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:


### PR DESCRIPTION
Cherry pick of #478 on release/3.9.

#478: fix(helm): nginx ingress annotations for HTTPS