### PR TITLE
fix(deploy): ocboot通过yaml配置文件进行部署时执行环境检测

### DIFF
--- a/run.py
+++ b/run.py
@@ -109,10 +109,11 @@ def install_passless_ssh(ipaddr):
         raise Exception("check passwordless ssh login failed")
 
 
-def check_env(ipaddr):
+def check_env(ipaddr=None):
     check_pip3()
     check_ansible()
-    check_passless_ssh(ipaddr)
+    if ipaddr:
+        check_passless_ssh(ipaddr)
 
 
 def random_password(num):
@@ -255,6 +256,7 @@ def main():
         check_env(ip_conf)
         conf = gen_config(ip_conf)
     elif path.isfile(ip_conf):
+        check_env()
         conf = ip_conf
     else:
         print("Wrong args!")


### PR DESCRIPTION
## 这个 PR 实现什么功能/修复什么问题:

* ocboot通过yaml配置文件进行部署时执行环境检测
* 之前环境检测只在输入ip时才检测。本次加上了yaml文件分支的检测。

## 是否需要 backport 到之前的 release 分支:

* release/3.9
