### PR TITLE
Automated cherry pick of #522: ocboot 部署时 mask 不能解析成 int 应该默认成 30

### DIFF
--- a/onecloud/roles/primary-master-node/setup_cloud/tasks/main.yml
+++ b/onecloud/roles/primary-master-node/setup_cloud/tasks/main.yml
@@ -15,8 +15,16 @@
     default_ip: "{{ default_ip_ret.stdout }}"
 
 - name: "Get default ip address {{ default_ip }} masklen"
-  shell: "ip route list | grep -w {{ default_ip }} | head -n 1 | awk '{print $1}' | cut -d '/' -f 2"
+  shell: |
+    masklen="$(ip route list | grep -w {{ default_ip }} | head -n 1 | awk '{print $1}' | cut -d '/' -f 2)"
+    if [[ "$masklen" =~ ^[0-9]+$ ]]; then
+      echo "$masklen"
+    else
+      echo "30"
+    fi
   register: default_masklen_ret
+  args:
+    executable: /bin/bash
 
 - name: Set default ip masklen
   set_fact:


### PR DESCRIPTION
Cherry pick of #522 on release/3.8.

#522: ocboot 部署时 mask 不能解析成 int 应该默认成 30