### PR TITLE
fix(python): 升级模式不再强行设置interpreter

### DIFF
--- a/lib/cmd.py
+++ b/lib/cmd.py
@@ -53,7 +53,8 @@ def run_ansible_playbook(hosts_f, playbook_f, debug_level=0, vars=None):
         cmd.extend(["-e", "@%s" % vars_f])
 
     cmd.extend(["-i", hosts_f, playbook_f])
-    cmd.extend(["-e", "ansible_python_interpreter=/usr/bin/python3"])
+    if not 'upgrade-cluster.yml' in playbook_f:
+        cmd.extend(["-e", "ansible_python_interpreter=/usr/bin/python3"])
 
     if len(debug_flag) > 0:
         cmd.append(debug_flag)


### PR DESCRIPTION
## 这个 PR 实现什么功能/修复什么问题:

* 升级模式不再强行设置interpreter

## 是否需要 backport 到之前的 release 分支:

* release/3.9
