### PR TITLE
Automated cherry pick of #528: fix(python): 升级模式不再强行设置interpreter

### DIFF
--- a/lib/cmd.py
+++ b/lib/cmd.py
@@ -53,7 +53,8 @@ def run_ansible_playbook(hosts_f, playbook_f, debug_level=0, vars=None):
         cmd.extend(["-e", "@%s" % vars_f])
 
     cmd.extend(["-i", hosts_f, playbook_f])
-    cmd.extend(["-e", "ansible_python_interpreter=/usr/bin/python3"])
+    if not 'upgrade-cluster.yml' in playbook_f:
+        cmd.extend(["-e", "ansible_python_interpreter=/usr/bin/python3"])
 
     if len(debug_flag) > 0:
         cmd.append(debug_flag)


### PR DESCRIPTION
Cherry pick of #528 on release/3.9.

#528: fix(python): 升级模式不再强行设置interpreter