### PR TITLE
Automated cherry pick of #582: fix(ha,upgrade,iso): iso升级高可用时使用主节点的nodeip而非高可用ip来同步文件

### DIFF
--- a/lib/upgrade.py
+++ b/lib/upgrade.py
@@ -77,6 +77,10 @@ def add_command(subparsers):
                         default="",
                         help="offline rpm repo path for upgrade mode")
 
+    parser.add_argument("--primary-node-ip",
+                        dest="primary_node_ip",
+                        default="",
+                        help="offline rpm repo path for upgrade mode")
     parser.set_defaults(func=do_upgrade)
 
 
@@ -109,6 +113,10 @@ def do_upgrade(args):
     if args.offline_data_path:
         vars['offline_data_path'] = args.offline_data_path
         vars['primary_master_host'] = args.primary_master_host
+
+    # for sync files. no ha ip.
+    if args.primary_node_ip:
+        vars['primary_node_ip'] = args.primary_node_ip
 
     return_code = run_ansible_playbook(
         inventory_f,

--- a/onecloud/roles/upgrade/common/tasks/v3_8-v3_9.yml
+++ b/onecloud/roles/upgrade/common/tasks/v3_8-v3_9.yml
@@ -9,14 +9,14 @@
     dest: "{{ item }}"
     delete: yes
     recursive: yes
-  delegate_to: "{{ primary_master_host }}"
+  delegate_to: "{{ primary_node_ip }}"
   with_items:
     - /etc/yum.repos.d/yunion.repo
     - "{{ offline_data_path }}/repodata/"
     - "{{ offline_data_path }}/rpms/"
   when:
-  - primary_master_host is defined
-  - primary_master_host != ansible_default_ipv4.address
+  - primary_node_ip is defined
+  - primary_node_ip != ansible_default_ipv4.address
 
 - name: "Add cloud rpm repository {{ yunion_yum_repo }}"
   get_url:

--- a/onecloud/roles/upgrade/common/tasks/v3_9-v3_10.yml
+++ b/onecloud/roles/upgrade/common/tasks/v3_9-v3_10.yml
@@ -9,14 +9,14 @@
     dest: "{{ item }}"
     delete: yes
     recursive: yes
-  delegate_to: "{{ primary_master_host }}"
+  delegate_to: "{{ primary_node_ip }}"
   with_items:
     - /etc/yum.repos.d/yunion.repo
     - "{{ offline_data_path }}/repodata/"
     - "{{ offline_data_path }}/rpms/"
   when:
-  - primary_master_host is defined
-  - primary_master_host != ansible_default_ipv4.address
+  - primary_node_ip is defined
+  - primary_node_ip != ansible_default_ipv4.address
 
 - name: "Add cloud rpm repository {{ yunion_yum_repo }}"
   get_url:


### PR DESCRIPTION
Cherry pick of #582 on release/3.10.

#582: fix(ha,upgrade,iso): iso升级高可用时使用主节点的nodeip而非高可用ip来同步文件