### PR TITLE
Automated cherry pick of #585: fix(ansible,env): 执行ansible-playbook之前检测并更新PATH变量，确保包含/usr/local/bin

### DIFF
--- a/lib/cmd.py
+++ b/lib/cmd.py
@@ -4,6 +4,10 @@ import os
 
 from lib import utils
 
+def init_ansible_playbook_path():
+    if '/usr/local/bin' not in os.environ.get('PATH', '').split(':'):
+        os.environ['PATH'] = '/usr/local/bin:' + os.environ.get('PATH', '')
+
 
 def get_ansible_config_path():
     return os.path.join(os.getcwd(), 'onecloud/ansible.cfg')
@@ -17,6 +21,7 @@ def _run_cmd(cmds):
     if not os.path.exists(config_file):
         raise Exception("Not found file %s" % config_file)
     os.environ['ANSIBLE_CONFIG'] = get_ansible_config_path()
+    init_ansible_playbook_path()
     proc = subprocess.Popen(
         shell_cmd,
         shell=True,

--- a/run.py
+++ b/run.py
@@ -10,6 +10,7 @@ import sys
 import re
 import argparse
 from lib import install
+from lib import cmd
 
 
 def show_usage():
@@ -41,6 +42,7 @@ def check_pip3():
 
 def check_ansible():
     minimal_ansible_version = '2.9.27'
+    cmd.init_ansible_playbook_path()
     ret = os.system("ansible-playbook --version >/dev/null 2>&1")
     if ret == 0:
         ansible_version = os.popen("""ansible-playbook --version | head -1 | grep -oP '[0-9.]+' """).read().strip()


### PR DESCRIPTION
Cherry pick of #585 on release/3.10.

#585: fix(ansible,env): 执行ansible-playbook之前检测并更新PATH变量，确保包含/usr/local/bin