### PR TITLE
Automated cherry pick of #662: fix(host,node): 添加计算节点时，启用host agent的逻辑应该和控制节点的一致

### DIFF
--- a/lib/add_node.py
+++ b/lib/add_node.py
@@ -87,8 +87,8 @@ class AddNodesConfig(object):
             'hosts': nodes_conf,
             'controlplane_host': controlplane_host,
             'ad_controller': False,
-            'as_host': True,
-            'as_host_on_vm': True,
+            'as_host': False,
+            'as_host_on_vm': False,
             'controlplane_ssh_port': controlplane_ssh_port,
         }
         self.worker_config = WorkerConfig(Config(woker_config_dict))

--- a/lib/ocboot.py
+++ b/lib/ocboot.py
@@ -533,7 +533,7 @@ class WorkerConfig(OnecloudJointConfig):
         if self.as_host is None:
             self.as_host = True
         if self.as_host_on_vm is None:
-            self.as_host_on_vm = True
+            self.as_host_on_vm = False
         self.nodes = get_nodes(config, bastion_host)
 
     @classmethod


### PR DESCRIPTION
Cherry pick of #662 on release/3.10.

#662: fix(host,node): 添加计算节点时，启用host agent的逻辑应该和控制节点的一致