### PR TITLE
Automated cherry pick of #676: fix(kernel,reboot): v3.9 通过ocboot同时部署控制+计算节点时，控制节点没有安装带yn的内核(8800)

### DIFF
--- a/onecloud/roles/primary-master-node/reboot/tasks/main.yml
+++ b/onecloud/roles/primary-master-node/reboot/tasks/main.yml
@@ -2,7 +2,6 @@
   include_role:
     name: utils/kernel-check
   when:
-    - k8s_node_as_oc_host|default(false)|bool == true
     - is_kylin_based|default(false)|bool == false
   vars:
     must_reboot: true


### PR DESCRIPTION
Cherry pick of #676 on release/3.9.

#676: fix(kernel,reboot): v3.9 通过ocboot同时部署控制+计算节点时，控制节点没有安装带yn的内核(8800)