### PR TITLE
Update run.py to include python3 explicitly

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # encoding: utf-8
 from __future__ import unicode_literals
 from __future__ import absolute_import


### PR DESCRIPTION
In my environment, python was defaulting to python 2.x version and throwing up lot of import errors.  Since, this project needs python 3, we should call it out.