### PR TITLE
Automated cherry pick of #698: fix: toggle -sync-user option when installing cluster

### DIFF
--- a/onecloud/roles/primary-master-node/setup_cloud/tasks/main.yml
+++ b/onecloud/roles/primary-master-node/setup_cloud/tasks/main.yml
@@ -104,8 +104,6 @@
 - name: add sync-user option
   include_role:
     name: utils/sync-user/on
-  when:
-  -  keepalived_version_tag is defined
 
 - name: Create essential services, wait for a few minutes...
   shell: "/opt/yunion/bin/ocadm cluster create {{ init_cluster_args }} --wait"
@@ -116,12 +114,6 @@
   ignore_errors: yes
   when:
   - OC_CLUSTER_COUNT.stdout|int == 0
-
-- name: rm sync-user option
-  include_role:
-    name: utils/sync-user/off
-  when:
-  -  keepalived_version_tag is defined
 
 - name: Enable minio S3 object storage for services
   environment:
@@ -235,6 +227,10 @@
   ignore_errors: yes
   args:
     executable: /bin/bash
+
+- name: rm sync-user option
+  include_role:
+    name: utils/sync-user/off
 
 - name: "post install scripts"
   shell: |


### PR DESCRIPTION
Cherry pick of #698 on release/3.9.

#698: fix: toggle -sync-user option when installing cluster