### PR TITLE
fix(update,openvswitch): 3.9升级到3.10的时候需要升级 openvswith rpm包到 2.12.4-1

### DIFF
--- a/onecloud/roles/upgrade/common/tasks/v3_9-v3_10.yml
+++ b/onecloud/roles/upgrade/common/tasks/v3_9-v3_10.yml
@@ -56,6 +56,7 @@
       - yunion-climc-ee
       - yunion-executor
       - yunion-qemu-4.2.0
+      - openvswitch
     disablerepo: "*"
     enablerepo: "yunion-*"
     state: latest


### PR DESCRIPTION
/cc @zexi

## 这个 PR 实现什么功能/修复什么问题:

* 3.9升级到3.10的时候需要升级 openvswith rpm包到 2.12.4-1

## 是否需要 backport 到之前的 release 分支:

* release/3.10