### PR TITLE
Automated cherry pick of #722: fix(update,openvswitch): 3.9升级到3.10的时候需要升级 openvswith rpm包到 2.12.4-1

### DIFF
--- a/onecloud/roles/upgrade/common/tasks/v3_9-v3_10.yml
+++ b/onecloud/roles/upgrade/common/tasks/v3_9-v3_10.yml
@@ -56,6 +56,7 @@
       - yunion-climc-ee
       - yunion-executor
       - yunion-qemu-4.2.0
+      - openvswitch
     disablerepo: "*"
     enablerepo: "yunion-*"
     state: latest


### PR DESCRIPTION
Cherry pick of #722 on release/3.10.

#722: fix(update,openvswitch): 3.9升级到3.10的时候需要升级 openvswith rpm包到 2.12.4-1