### PR TITLE
fix(clickhouse,meter): 解决clickhouse的meter部署问题

### DIFF
--- a/onecloud/roles/clickhouse/deploy/tasks/main.yml
+++ b/onecloud/roles/clickhouse/deploy/tasks/main.yml
@@ -9,17 +9,27 @@
     environment:
       KUBECONFIG: /etc/kubernetes/admin.conf
     shell: |
-      kubectl patch onecloudclusters -n onecloud default --patch "$(cat /tmp/clickhouse.spec.yaml)" --type merge && rm -f /tmp/clickhouse.spec.yaml
+      kubectl patch onecloudclusters -n onecloud default --patch "$(cat /tmp/clickhouse.spec.yaml)" --type merge
       for i in cloudevent glance keystone region kubeserver logger meter monitor notify webconsole
       do
         kubectl delete configmap -n onecloud default-$i
         kubectl rollout restart deployment -n onecloud  default-$i
       done
+      sleep 30
+      kubectl -n onecloud get configmap default-meter -o yaml | grep -qP '^\s+clickhouse: tcp'
     args:
       executable: /bin/bash
+    retries: 10
+    register: clickhouse_result
+    delay: 30
+    ignore_errors: true
+    until: clickhouse_result.rc == 0
+
+  - name: clean tmp files
+    shell: |
+      rm -f /tmp/clickhouse.spec.yaml
 
   when:
   - offline_data_path is defined
   - offline_data_path | length > 0
   - is_centos_x86 | default(false) | bool == true
-


### PR DESCRIPTION
/cc @zexi

## 这个 PR 实现什么功能/修复什么问题:

* 解决clickhouse的meter部署问题,增加了meter 的configmap 的检测和重试

## 是否需要 backport 到之前的 release 分支:

* release/3.9
* release/3.10