### PR TITLE
fix(backup): 自动备份:删除某些配置行

### DIFF
--- a/onecloud/roles/utils/auto-backup-services/files/db_backup.sh
+++ b/onecloud/roles/utils/auto-backup-services/files/db_backup.sh
@@ -261,6 +261,8 @@ backup_k8s() {
     title "Backup K8s"
     kubectl -n onecloud -o yaml get deployment onecloud-operator >$BKUP_PATH/onecloud-operator.$BKUP_DATE.yml
     kubectl -n onecloud -o yaml get oc >$BKUP_PATH/oc.$BKUP_DATE.yml
+    sed -i -e '/^ *creationTimestamp:/d' -e '/^ *resourceVersion:/d' -e '/^ *selfLink:/d' -e '/^ *uid:/d' $BKUP_PATH/onecloud-operator.$BKUP_DATE.yml
+    sed -i -e '/^ *creationTimestamp:/d' -e '/^ *resourceVersion:/d' -e '/^ *selfLink:/d' -e '/^ *uid:/d' $BKUP_PATH/oc.$BKUP_DATE.yml
     __info "K8s backup files:"
     find $BKUP_PATH -name '*yml' -type f | xargs ls -lah
 }

--- a/onecloud/roles/utils/auto-backup-services/tasks/main.yml
+++ b/onecloud/roles/utils/auto-backup-services/tasks/main.yml
@@ -7,10 +7,16 @@
     mode: 0755
   become: true
 
+- name: rm old auto backup cronjob if any
+  cron:
+    name: "Backup DB Daily"
+    state: absent
+    cron_file: yunion_audo_db_backup
+
 - name: add cronjob to backup db every day.
   cron:
     name: "Backup DB Daily"
     special_time: daily
     user: root
     job: "BKUP_PATH={{ backup_path | default('/opt/yunion/backup')}} MAX_BKUP={{ max_backups|default(10) }} LIGHT_BKUP={{light_backup|default('true')}} MAX_DISK_PERCENTAGE={{ max_disck_percentage|default(75) }} /opt/yunion/scripts/db_backup.sh"
-    cron_file: yunion_audo_db_backup
+    cron_file: yunion_auto_db_backup


### PR DESCRIPTION
/cc @zexi

## 这个 PR 实现什么功能/修复什么问题:

* 自动备份oc和operator的yaml文件中去掉creationTimestamp、resourceVersion、selfLink和uid这四行
* typo fix

## 是否需要 backport 到之前的 release 分支:

* release/3.9
* release/3.10