### PR TITLE
fix(debian): install libcapstone4 for qemu under debian 11

### DIFF
--- a/onecloud/roles/common/tasks/debian.yml
+++ b/onecloud/roles/common/tasks/debian.yml
@@ -101,6 +101,12 @@
   args:
     executable: /bin/bash
 
+- name: update common packages for debian 11 
+  set_fact:
+    common_packages: "{{ ['libcapstone4'] + common_packages }}"
+  when: 
+  - is_debian_11_or_later| default(false)|bool == true
+
 - name: install common packages via loop
   package:
     name: "{{ item }}"


### PR DESCRIPTION
/cc @zexi

## 这个 PR 实现什么功能/修复什么问题:

* install libcapstone4 for qemu under debian 11

## 是否需要 backport 到之前的 release 分支:

* release/3.10