### PR TITLE
Automated cherry pick of #831: fix(debian): install libcapstone4 for qemu under debian 11

### DIFF
--- a/onecloud/roles/common/tasks/debian.yml
+++ b/onecloud/roles/common/tasks/debian.yml
@@ -101,6 +101,12 @@
   args:
     executable: /bin/bash
 
+- name: update common packages for debian 11 
+  set_fact:
+    common_packages: "{{ ['libcapstone4'] + common_packages }}"
+  when: 
+  - is_debian_11_or_later| default(false)|bool == true
+
 - name: install common packages via loop
   package:
     name: "{{ item }}"


### PR DESCRIPTION
Cherry pick of #831 on release/3.10.

#831: fix(debian): install libcapstone4 for qemu under debian 11