### PR TITLE
Automated cherry pick of #833: fix(networkmanager): 在重启networkmanager 前后，确保resolev.conf 不改变

### DIFF
--- a/onecloud/roles/utils/config-network-manager/handlers/main.yml
+++ b/onecloud/roles/utils/config-network-manager/handlers/main.yml
@@ -1,5 +1,14 @@
+
 - name: Reload NetworkManager
   service:
     name: NetworkManager
     state: reloaded
   when: '"running" in nm_check.stdout'
+  notify:
+    - Remove immutable flag on /etc/resolv.conf
+
+- name: Remove immutable flag on /etc/resolv.conf
+  shell: |
+    chattr -i /etc/resolv.conf
+  ignore_errors: yes
+

--- a/onecloud/roles/utils/config-network-manager/tasks/main.yml
+++ b/onecloud/roles/utils/config-network-manager/tasks/main.yml
@@ -18,5 +18,14 @@
       [keyfile]
       unmanaged-devices=interface-name:cali*;interface-name:tunl*
     dest: /etc/NetworkManager/conf.d/calico.conf
-  when: nm_check.rc == 0
+  when: 
+  - nm_check.rc == 0
+
+- name: reload NetworkManager
+  shell: |
+    chattr +i /etc/resolv.conf || :
+    echo "nm_service is defined? {{ nm_service is defined }}\nnm_service.state {{ nm_service.state | default('stopped') == 'started' }}"
+  when:
+  - nm_service is defined
+  - nm_service.state | default('stopped') == 'started'
   notify: Reload NetworkManager


### PR DESCRIPTION
Cherry pick of #833 on release/3.9.

#833: fix(networkmanager): 在重启networkmanager 前后，确保resolev.conf 不改变