### PR TITLE
fix(repo): 优化redhat家族os在线/离线安装时的repo判断问题

### DIFF
--- a/onecloud/roles/clickhouse/install/tasks/centos.yml
+++ b/onecloud/roles/clickhouse/install/tasks/centos.yml
@@ -2,8 +2,8 @@
   package:
     name: "{{ item }}"
     state: "present"
-    disablerepo: "{{ disablerepo }}"
-    enablerepo: "{{ enablerepo }}"
+    disablerepo: "{{ (online_status != 'online') | ternary('*', omit) }}"
+    enablerepo: "{{ (online_status != 'online') | ternary('yunion-*', omit) }}"
   with_items:
     - clickhouse-server
     - clickhouse-client

--- a/onecloud/roles/clickhouse/install/tasks/kylin_linux_advanced_server.yml
+++ b/onecloud/roles/clickhouse/install/tasks/kylin_linux_advanced_server.yml
@@ -2,8 +2,8 @@
   package:
     name: "{{ item }}"
     state: "present"
-    disablerepo: "{{ disablerepo }}"
-    enablerepo: "{{ enablerepo }}"
+    disablerepo: "{{ (online_status != 'online') | ternary('*', omit) }}"
+    enablerepo: "{{ (online_status != 'online') | ternary('yunion-*', omit) }}"
   with_items:
   - clickhouse-server
   - clickhouse-client

--- a/onecloud/roles/common/tasks/centos_7_x86_64.yml
+++ b/onecloud/roles/common/tasks/centos_7_x86_64.yml
@@ -9,8 +9,8 @@
 - name: install common packages via loop
   package:
     name: "{{ item }}"
-    disablerepo: "{{ disablerepo }}"
-    enablerepo: "{{ enablerepo }}"
+    disablerepo: "{{ (online_status != 'online') | ternary('*', omit) }}"
+    enablerepo: "{{ (online_status != 'online') | ternary('yunion-*', omit) }}"
   with_items:
   - "{{ common_packages }}"
   loop_control:
@@ -21,8 +21,8 @@
   package:
     name: "{{ item }}"
     state: latest
-    disablerepo: "{{ disablerepo }}"
-    enablerepo: "{{ enablerepo }}"
+    disablerepo: "{{ (online_status != 'online') | ternary('*', omit) }}"
+    enablerepo: "{{ (online_status != 'online') | ternary('yunion-*', omit) }}"
   with_items:
   - "{{ latest_packages }}"
   retries: 6
@@ -34,7 +34,10 @@
   - latest_packages is defined
 
 - name: install misc obsolete packages
-  package: name="{{ item }}" disablerepo="*" enablerepo="yunion-*"
+  package:
+    name: "{{ item }}"
+    disablerepo: "{{ (online_status != 'online') | ternary('*', omit) }}"
+    enablerepo: "{{ (online_status != 'online') | ternary('yunion-*', omit) }}"
   with_items:
   - yunion-qemu-2.12.1
   when:

--- a/onecloud/roles/common/tasks/master.yml
+++ b/onecloud/roles/common/tasks/master.yml
@@ -11,8 +11,8 @@
 - name: Install cloud common packages
   yum:
     state: latest
-    enablerepo: "yunion*"
-    disablerepo: "{{ disablerepo }}"
+    enablerepo: "{{ (online_status != 'online') | ternary('yunion-*', omit) }}"
+    disablerepo: "{{ (online_status != 'online') | ternary('*', omit) }}"
     name:
       - yunion-executor
   when:

--- a/onecloud/roles/common/tasks/v3_8.yml
+++ b/onecloud/roles/common/tasks/v3_8.yml
@@ -18,8 +18,8 @@
 - name: Install cloud common packages
   yum:
     state: latest
-    enablerepo: "yunion*"
-    disablerepo: "{{ disablerepo }}"
+    enablerepo: "{{ (online_status != 'online') | ternary('yunion-*', omit) }}"
+    disablerepo: "{{ (online_status != 'online') | ternary('*', omit) }}"
     name:
       - kernel-3.10.0-1160.6.1.el7.yn20201125
       - kernel-devel-3.10.0-1160.6.1.el7.yn20201125

--- a/onecloud/roles/mariadb/tasks/centos-x86_64.yml
+++ b/onecloud/roles/mariadb/tasks/centos-x86_64.yml
@@ -2,8 +2,8 @@
   package:
     name: "{{ item }}"
     state: "present"
-    disablerepo: "{{ disablerepo }}"
-    enablerepo: "{{ enablerepo }}"
+    disablerepo: "{{ (online_status != 'online') | ternary('*', omit) }}"
+    enablerepo: "{{ (online_status != 'online') | ternary('yunion-*', omit) }}"
   with_items:
     - mariadb-server
 

--- a/onecloud/roles/mariadb/tasks/kylin_linux_advanced_server-aarch64.yml
+++ b/onecloud/roles/mariadb/tasks/kylin_linux_advanced_server-aarch64.yml
@@ -2,8 +2,8 @@
   package:
     name: "{{ item }}"
     state: installed
-    disablerepo: "{{ disablerepo }}"
-    enablerepo: "{{ enablerepo }}"
+    disablerepo: "{{ (online_status != 'online') | ternary('*', omit) }}"
+    enablerepo: "{{ (online_status != 'online') | ternary('yunion-*', omit) }}"
   with_items:
   - mariadb-server
 

--- a/onecloud/roles/mariadb/tasks/kylin_linux_advanced_server-x86_64.yml
+++ b/onecloud/roles/mariadb/tasks/kylin_linux_advanced_server-x86_64.yml
@@ -2,8 +2,8 @@
   package:
     name: "{{ item }}"
     state: installed
-    disablerepo: "{{ disablerepo }}"
-    enablerepo: "{{ enablerepo }}"
+    disablerepo: "{{ (online_status != 'online') | ternary('*', omit) }}"
+    enablerepo: "{{ (online_status != 'online') | ternary('yunion-*', omit) }}"
   with_items:
   - mariadb-server
 

--- a/onecloud/roles/registry/tasks/main.yml
+++ b/onecloud/roles/registry/tasks/main.yml
@@ -1,5 +1,9 @@
 - name: Install registry
-  yum: name={{ item }} disablerepo="*" state=present enablerepo="yunion-*"
+  yum:
+    name: "{{ item }}"
+    disablerepo: "{{ (online_status != 'online') | ternary('*', omit) }}"
+    enablerepo: "{{ (online_status != 'online') | ternary('yunion-*', omit) }}"
+    state: present
   with_items:
   - yunion-registry
   when:

--- a/onecloud/roles/upgrade/common/tasks/v3_4-v3_6.yml
+++ b/onecloud/roles/upgrade/common/tasks/v3_4-v3_6.yml
@@ -27,8 +27,8 @@
       - yunion-climc
       - yunion-executor
     state: latest
-    disablerepo: '*'
-    enablerepo: "{{ enablerepo }}"
+    disablerepo: "{{ (online_status != 'online') | ternary('*', omit) }}"
+    enablerepo: "{{ (online_status != 'online') | ternary('yunion-*', omit) }}"
   when:
   - is_centos_x86 is defined
 

--- a/onecloud/roles/upgrade/common/tasks/v3_6-v3_7.yml
+++ b/onecloud/roles/upgrade/common/tasks/v3_6-v3_7.yml
@@ -40,8 +40,8 @@
       - kernel-3.10.0-1160.6.1.el7.yn20201125
       - kernel-devel-3.10.0-1160.6.1.el7.yn20201125
       - kernel-headers-3.10.0-1160.6.1.el7.yn20201125
-    disablerepo: "{{ disablerepo }}"
-    enablerepo: "{{ enablerepo }}"
+    disablerepo: "{{ (online_status != 'online') | ternary('*', omit) }}"
+    enablerepo: "{{ (online_status != 'online') | ternary('yunion-*', omit) }}"
     state: latest
   when:
   - is_centos_x86 is defined

--- a/onecloud/roles/upgrade/common/tasks/v3_7-v3_8.yml
+++ b/onecloud/roles/upgrade/common/tasks/v3_7-v3_8.yml
@@ -45,8 +45,8 @@
       - yunion-ocadm
       - yunion-climc
       - yunion-executor
-    disablerepo: "{{ disablerepo }}"
-    enablerepo: "{{ enablerepo }}"
+    disablerepo: "{{ (online_status != 'online') | ternary('*', omit) }}"
+    enablerepo: "{{ (online_status != 'online') | ternary('yunion-*', omit) }}"
     state: latest
   when:
   - is_centos_based is defined

--- a/onecloud/roles/upgrade/common/tasks/v3_8-v3_9.yml
+++ b/onecloud/roles/upgrade/common/tasks/v3_8-v3_9.yml
@@ -56,8 +56,8 @@
       - yunion-climc-ee
       - yunion-executor
       - yunion-qemu-4.2.0
-    disablerepo: "{{ disablerepo }}"
-    enablerepo: "{{ enablerepo }}"
+    disablerepo: "{{ (online_status != 'online') | ternary('*', omit) }}"
+    enablerepo: "{{ (online_status != 'online') | ternary('yunion-*', omit) }}"
     state: latest
   when:
   - is_centos_based is defined

--- a/onecloud/roles/upgrade/common/tasks/v3_9-v3_10.yml
+++ b/onecloud/roles/upgrade/common/tasks/v3_9-v3_10.yml
@@ -57,8 +57,8 @@
       - yunion-executor
       - yunion-qemu-4.2.0
       - openvswitch
-    disablerepo: "{{ disablerepo }}"
-    enablerepo: "{{ enablerepo }}"
+    disablerepo: "{{ (online_status != 'online') | ternary('*', omit) }}"
+    enablerepo: "{{ (online_status != 'online') | ternary('yunion-*', omit) }}"
     state: latest
   when:
   - is_centos_based is defined

--- a/onecloud/roles/upgrade/primary_master_node/tasks/main.yml
+++ b/onecloud/roles/upgrade/primary_master_node/tasks/main.yml
@@ -7,8 +7,8 @@
   yum:
     name:
       - yunion-ocadm
-    disablerepo: "{{ disablerepo }}"
-    enablerepo: "{{ enablerepo }}"
+    disablerepo: "{{ (online_status != 'online') | ternary('*', omit) }}"
+    enablerepo: "{{ (online_status != 'online') | ternary('yunion-*', omit) }}"
     state: latest
   when:
   - is_centos_based is defined

--- a/onecloud/roles/utils/detect-os/tasks/main.yml
+++ b/onecloud/roles/utils/detect-os/tasks/main.yml
@@ -25,11 +25,6 @@
     offline_data_path: "{{ lookup('env', 'OFFLINE_DATA_PATH') }}"
     online_status: "{{ (lookup('env', 'OFFLINE_DATA_PATH') | length > 0) | ternary('offline', 'online') }}"
 
-- name: set vars for yum repos
-  set_fact:
-    disablerepo: "{{ '' if online_status == 'online' else '*' }}"
-    enablerepo: "{{ '*' if online_status == 'online' else 'yunion-*' }}"
-
 - name: will start {{ online_status | upper }} deploy
   shell: exit 0
 

--- a/onecloud/roles/utils/kernel-check/tasks/centos-aarch64.yml
+++ b/onecloud/roles/utils/kernel-check/tasks/centos-aarch64.yml
@@ -1,6 +1,6 @@
 - name: Install Cloud Kernel
   yum:
-    enablerepo: "yunion*"
-    disablerepo: "{{ disablerepo }}"
+    disablerepo: "{{ (online_status != 'online') | ternary('*', omit) }}"
+    enablerepo: "{{ (online_status != 'online') | ternary('yunion-*', omit) }}"
     name:
       - kernel-5.4.199-200.yn20221212.el7

--- a/onecloud/roles/utils/kernel-check/tasks/centos-x86_64.yml
+++ b/onecloud/roles/utils/kernel-check/tasks/centos-x86_64.yml
@@ -2,8 +2,8 @@
 
 - name: Install Cloud Kernel
   yum:
-    enablerepo: "yunion*"
-    disablerepo: "{{ disablerepo }}"
+    enablerepo: "{{ (online_status != 'online') | ternary('yunion-*', omit) }}"
+    disablerepo: "{{ (online_status != 'online') | ternary('*', omit) }}"
     name:
     - kernel-5.4.130-1.yn20221208.el7
     - kernel-devel-5.4.130-1.yn20221208.el7

--- a/run.py
+++ b/run.py
@@ -70,7 +70,7 @@ def check_ansible():
 
 def install_packages(pkgs):
     if os.system('grep -Pq "Kylin Linux Advanced Server|CentOS Linux|openEuler" /etc/os-release') == 0:
-        return os.system("yum install -y %s" % (" ".join(pkgs)))
+        return os.system("yum install -y $(yum search pyyaml |grep -iP '^python3\d?-pyyaml\.'| awk '{print $1}') %s" % (" ".join(pkgs)))
     elif os.system('grep -wq "Debian GNU/Linux" /etc/os-release') == 0:
         return os.system("apt install -y %s" % (" ".join(pkgs)))
     else:


### PR DESCRIPTION
/cc @zexi

## 这个 PR 实现什么功能/修复什么问题:

* 优化redhat家族os在线/离线安装时的repo判断问题

## 是否需要 backport 到之前的 release 分支:

* release/3.9
* release/3.10