### PR TITLE
fix(clickhouse,ip): 解决clickhouse部署时ip选择的问题

### DIFF
--- a/lib/cmd.py
+++ b/lib/cmd.py
@@ -61,6 +61,9 @@ def run_ansible_playbook(hosts_f, playbook_f, debug_level=0, vars=None):
 
     if len(debug_flag) > 0:
         cmd.append(debug_flag)
+    skip_tags = os.environ.get('SKIP_TAGS', "")
+    if len(skip_tags) > 0:
+        cmd.extend(["--skip-tags", f"'{skip_tags}'"])
     return _run_cmd(cmd)
 
 

--- a/onecloud/roles/clickhouse/deploy/templates/clickhouse.spec.j2
+++ b/onecloud/roles/clickhouse/deploy/templates/clickhouse.spec.j2
@@ -1,6 +1,6 @@
 spec:
   clickhouse:
     username: "default"
-    host: {{ ansible_default_ipv4.address }}
+    host: {{ node_ip }}
     password: {{ ch_password }}
     port: {{ ch_port }}

--- a/onecloud/roles/common/tasks/centos_7_x86_64.yml
+++ b/onecloud/roles/common/tasks/centos_7_x86_64.yml
@@ -17,6 +17,8 @@
     index_var: item_index
     label: "[{{ item_index + 1 }}/{{ common_packages|length }}] {{ package_item }}"
     loop_var: package_item
+  tags:
+  - package
 
 - name: install latest packages via loop
   package:
@@ -37,6 +39,8 @@
     index_var: item_index
     label: "[{{ item_index + 1 }}/{{ latest_packages | length }}] {{ package_item }}"
     loop_var: package_item
+  tags:
+  - package
 
 - name: install misc obsolete packages
   package:
@@ -46,11 +50,12 @@
   loop_control:
     index_var: item_index
     loop_var: package_item
-
   with_items:
   - yunion-qemu-2.12.1
   when:
   - is_centos_x86 is defined
+  tags:
+  - package
 
 - name: Selinux Status
   shell: |

--- a/onecloud/roles/common/tasks/debian.yml
+++ b/onecloud/roles/common/tasks/debian.yml
@@ -111,6 +111,8 @@
     index_var: item_index
     label: "[{{ item_index + 1 }}/{{ common_packages|length }}] {{ package_item }}"
     loop_var: package_item
+  tags:
+  - package
 
 - name: install latest packages via loop
   package:
@@ -124,6 +126,8 @@
     index_var: item_index
     label: "[{{ item_index + 1 }}/{{ common_packages|length }}] {{ package_item }}"
     loop_var: package_item
+  tags:
+  - package
 
 - name: Check that if selinux config exists
   stat:

--- a/onecloud/roles/common/tasks/uniontech-kongzi.yml
+++ b/onecloud/roles/common/tasks/uniontech-kongzi.yml
@@ -31,7 +31,7 @@
       mkdir -p /usr/local/containerd
       tar xzvf /tmp/containerd-1.7.2-linux.tar.gz -C /usr/local/containerd
       for i in /usr/local/containerd/bin/*
-      do 
+      do
         ln -sf $i /usr/bin/
       done
       cat > /usr/lib/systemd/system/containerd.service <<-EOF
@@ -90,6 +90,8 @@
     index_var: item_index
     label: "[{{ item_index + 1 }}/{{ common_packages|length }}] {{ package_item }}"
     loop_var: package_item
+  tags:
+  - package
 
 - name: install latest packages via loop
   package:
@@ -110,6 +112,8 @@
     index_var: item_index
     label: "[{{ item_index + 1 }}/{{ latest_packages | length }}] {{ package_item }}"
     loop_var: package_item
+  tags:
+  - package
 
 - name: Selinux Status
   shell: |

--- a/onecloud/roles/utils/load-images/tasks/main.yml
+++ b/onecloud/roles/utils/load-images/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: offline_nodes type list
   set_fact:
-    offline_node_list: "{{ offline_node_list + [ansible_default_ipv4.address] }}"
+    offline_node_list: "{{ offline_node_list + [node_ip] }}"
   when:
   - offline_data_path is defined
 


### PR DESCRIPTION
/cc @zexi

## 这个 PR 实现什么功能/修复什么问题:

* 解决clickhouse部署时ip选择的问题
* 顺便为某些job增加 tag，以便在重复测试安装时通过`--skip-tags` 的方式略过

## 是否需要 backport 到之前的 release 分支:

* release/3.9
* release/3.10