### PR TITLE
Automated cherry pick of #893: fix(ansible,syntax): 解决supported_os.keys 无法解析的问题

### DIFF
--- a/onecloud/roles/utils/misc-check/tasks/os.yml
+++ b/onecloud/roles/utils/misc-check/tasks/os.yml
@@ -1,6 +1,6 @@
 - name: set var
   set_fact:
-    supported_os:        
+    supported_os:
       uniontech:
         ansible_distribution_name: "UnionTech"
         conditions:
@@ -37,7 +37,7 @@
   set_fact:
     supported_os_name: true
     supported_os_key: "{{item}}"
-  loop: "{{ supported_os.keys() }}"
+  loop: "{{ supported_os.keys() | list }}"
   when:
   - ansible_distribution.startswith(supported_os[item].ansible_distribution_name)
 
@@ -50,7 +50,7 @@
 
 - name: Check if OS VERSION is supported
   assert:
-    that: "{{ item }}"        
+    that: "{{ item }}"
     fail_msg: "OS VER {{ ansible_distribution }} {{ ansible_distribution_version }} is NOT supported"
   with_items: "{{ supported_os[supported_os_key].conditions }}"
   when:


### PR DESCRIPTION
Cherry pick of #893 on release/3.10.

#893: fix(ansible,syntax): 解决supported_os.keys 无法解析的问题