### PR TITLE
fix(conf): 通过iso安装时，tui界面未勾选enable host agent 选项，部署完成后不应该启用 host agent

### DIFF
--- a/run.py
+++ b/run.py
@@ -278,6 +278,11 @@ def update_config(yaml_conf, produc_stack):
     yaml_data = {}
     to_write = False
 
+    offline_path = os.environ.get('OFFLINE_DATA_PATH', )
+    if offline_path:
+        pr_green('offline mode, no need to update config.')
+        return yaml_conf
+
     assert produc_stack in ocboot.KEY_STACK_LIST
     try:
         if path.isfile(yaml_conf) and path.getsize(yaml_conf) > 0:


### PR DESCRIPTION
/cc @zexi

## 这个 PR 实现什么功能/修复什么问题:

* 通过iso安装时，tui界面未勾选enable host agent 选项，部署完成后不应该启用 host agent

## 是否需要 backport 到之前的 release 分支:

* release/3.10
* release/3.11