### PR TITLE
Automated cherry pick of #1042: fix(conf): 通过iso安装时，tui界面未勾选enable host agent 选项，部署完成后不应该启用 host agent

### DIFF
--- a/run.py
+++ b/run.py
@@ -278,6 +278,11 @@ def update_config(yaml_conf, produc_stack):
     yaml_data = {}
     to_write = False
 
+    offline_path = os.environ.get('OFFLINE_DATA_PATH', )
+    if offline_path:
+        pr_green('offline mode, no need to update config.')
+        return yaml_conf
+
     assert produc_stack in ocboot.KEY_STACK_LIST
     try:
         if path.isfile(yaml_conf) and path.getsize(yaml_conf) > 0:


### PR DESCRIPTION
Cherry pick of #1042 on release/3.11.

#1042: fix(conf): 通过iso安装时，tui界面未勾选enable host agent 选项，部署完成后不应该启用 host agent