### PR TITLE
Automated cherry pick of #1048: fix: use shell environment directly when using kubectl patches resource

### DIFF
--- a/onecloud/roles/utils/k8s/addons/patch/tasks/main.yml
+++ b/onecloud/roles/utils/k8s/addons/patch/tasks/main.yml
@@ -4,10 +4,8 @@
     dest: "/tmp/{{ resource_name }}.patch.yml"
 
 - name: patch {{ resource }} {{ namespace }}/{{ resource_name }} onecloud.yunion.io/controller node selector
-  environment:
-    KUBECONFIG: /etc/kubernetes/admin.conf
   shell: |
-    kubectl patch {{ resource }} -n {{ namespace }} {{ resource_name }} --patch "$(cat /tmp/{{ resource_name }}.patch.yml)" --type merge && rm -f /tmp/{{ resource_name }}.patch.yml
+    KUBECONFIG=/etc/kubernetes/admin.conf kubectl patch {{ resource }} -n {{ namespace }} {{ resource_name }} --patch "$(cat /tmp/{{ resource_name }}.patch.yml)" --type merge && rm -f /tmp/{{ resource_name }}.patch.yml
   become: yes
   args:
     executable: /bin/bash


### PR DESCRIPTION
Cherry pick of #1048 on master.

#1048: fix: use shell environment directly when using kubectl patches resource