### PR TITLE
Automated cherry pick of #1057: fix: wrong NetworkManager configuration of interface-name

### DIFF
--- a/onecloud/roles/utils/config-network-manager/tasks/main.yml
+++ b/onecloud/roles/utils/config-network-manager/tasks/main.yml
@@ -22,11 +22,11 @@
   become: true
   when: nm_check.rc == 0
 
-- name: Prevent NetworkManager from managing Cluster interfaces
+- name: Prevent NetworkManager from managing Calico interfaces
   copy:
     content: |
       [keyfile]
-      unmanaged-devices=interface-name:cali*;interface-name:tunl*:br*
+      unmanaged-devices=interface-name:cali*;interface-name:tunl*
     dest: /etc/NetworkManager/conf.d/calico.conf
   become: true
   when:


### PR DESCRIPTION
Cherry pick of #1057 on release/3.11.

#1057: fix: wrong NetworkManager configuration of interface-name