### PR TITLE
Automated cherry pick of #1060: fix: prevent NetworkManager from managing host OVS interfaces

### DIFF
--- a/onecloud/roles/utils/config-network-manager/tasks/main.yml
+++ b/onecloud/roles/utils/config-network-manager/tasks/main.yml
@@ -22,11 +22,11 @@
   become: true
   when: nm_check.rc == 0
 
-- name: Prevent NetworkManager from managing Calico interfaces
+- name: Prevent NetworkManager from managing Calico and host OVS interfaces
   copy:
     content: |
       [keyfile]
-      unmanaged-devices=interface-name:cali*;interface-name:tunl*
+      unmanaged-devices=interface-name:cali*;interface-name:tunl*;interface-name:br*
     dest: /etc/NetworkManager/conf.d/calico.conf
   become: true
   when:


### PR DESCRIPTION
Cherry pick of #1060 on release/3.11.

#1060: fix: prevent NetworkManager from managing host OVS interfaces