### PR TITLE
Automated cherry pick of #1067: fix: use include_tasks because the include module is deprecated

### DIFF
--- a/onecloud/roles/utils/kernel-check/tasks/main.yml
+++ b/onecloud/roles/utils/kernel-check/tasks/main.yml
@@ -38,7 +38,7 @@
   failed_when: false
 
 - name: install customized kernel
-  include: "{{ ansible_distribution | lower }}-{{ ansible_architecture }}.yml"
+  include_tasks: "{{ ansible_distribution | lower }}-{{ ansible_architecture }}.yml"
   when:
   - nbd_ok|default(false)|bool == false
   - is_yunion_kernel_installed.rc != 0


### PR DESCRIPTION
Cherry pick of #1067 on release/3.9.

#1067: fix: use include_tasks because the include module is deprecated