### PR TITLE
Automated cherry pick of #1076: fix: set mysql group_concat_max_len=max_allowed_packet

### DIFF
--- a/lib/restore.py
+++ b/lib/restore.py
@@ -77,6 +77,7 @@ def ensure_db_config(args):
             '''FLUSH PRIVILEGES''',
             '''set global net_buffer_length=999424 ''',
             '''set global max_allowed_packet=999999488 ''',
+            '''set global group_concat_max_len=999999488 ''',
         ]
 
         db = DB()

--- a/onecloud/roles/mariadb-ha/templates/my.cnf.j2
+++ b/onecloud/roles/mariadb-ha/templates/my.cnf.j2
@@ -19,6 +19,7 @@ expire_logs_days=30
 innodb_file_per_table=ON
 max_connections = 300
 max_allowed_packet=20M
+group_concat_max_len=20M
 default_time_zone='+00:00'
 
 {% if inventory_hostname == groups['mariadb_ha_nodes'][0] %}
@@ -39,6 +40,7 @@ replicate-ignore-db = performance_schema
 max_connections = 1000
 max_connect_errors = 0
 max_allowed_packet = 1G
+group_concat_max_len = 1G
 slave-net-timeout=10
 master-retry-count=0
 

--- a/onecloud/roles/mariadb/files/my.cnf
+++ b/onecloud/roles/mariadb/files/my.cnf
@@ -14,6 +14,7 @@ expire_logs_days=30
 innodb_file_per_table=ON
 max_connections = 300
 max_allowed_packet=20M
+group_concat_max_len=20M
 default_time_zone='+00:00'
 
 [mysqld_safe]


### PR DESCRIPTION
Cherry pick of #1076 on release/3.11.

#1076: fix: set mysql group_concat_max_len=max_allowed_packet