### PR TITLE
feat(cloud): ocboot 默认开启火山引擎(从3.11)

### DIFF
--- a/onecloud/roles/primary-master-node/setup_cloud/tasks/main.yml
+++ b/onecloud/roles/primary-master-node/setup_cloud/tasks/main.yml
@@ -330,3 +330,9 @@
   become: yes
   args:
     executable: /bin/bash
+
+- name: Enable misc clouds
+  include_role:
+    name: utils/enable-misc-clouds
+  when:
+  - product_version | default('') in ['FullStack', 'CMP']

--- a/onecloud/roles/utils/enable-misc-clouds/tasks/main.yml
+++ b/onecloud/roles/utils/enable-misc-clouds/tasks/main.yml
@@ -1,0 +1,8 @@
+- name: Enable Volcano engine
+  environment:
+    KUBECONFIG: /etc/kubernetes/admin.conf
+  shell: |
+    source <(/opt/yunion/bin/ocadm cluster rcadmin)
+    /opt/yunion/bin/climc feature-config-volcengine --switch on
+  args:
+    executable: /bin/bash


### PR DESCRIPTION
/cc @zexi

## 这个 PR 实现什么功能/修复什么问题:

* ocboot 默认开启火山引擎(从3.11)

## 是否需要 backport 到之前的 release 分支:


* release/3.11