### PR TITLE
hotfix: ansible assert mark embedded variable unsafe

### DIFF
--- a/onecloud/roles/utils/bin-version-check/tasks/main.yml
+++ b/onecloud/roles/utils/bin-version-check/tasks/main.yml
@@ -31,12 +31,14 @@
   args:
     executable: /bin/bash
 
-- debug: var=yunion_bin_version_ret.stdout
+- name: set facts
+  set_fact:
+    YUNION_BIN_GT: "v{{onecloud_version_abbr}}"
 
 - name: Assert yunion bin version
   assert:
     that:
-      - '"{{item}}" is version(YUNION_BIN_GT, ">")'
+      - 'item is version(YUNION_BIN_GT, ">=")'
     fail_msg: "Yunion's version must be greater than {{ YUNION_BIN_GT }}, got {{ item }}."
   loop: "{{ yunion_bin_version_ret.stdout.split('\n') | list }}"
 
@@ -68,7 +70,8 @@
 - name: Assert kubelet version
   assert:
     that:
-      - - '"{{item}}" is version(K8S_VERSION_GE, ">=")'
-      - - '"{{item}}" is version(K8S_VERSION_LT, "<")'
+      - 'item is version(K8S_VERSION_GE, ">=")'
+      - 'item is version(K8S_VERSION_LT, "<")'
     fail_msg: "k8s's version must be {{K8S_VERSION_GE}}~{{K8S_VERSION_LT}}, got {{item}}."
   loop: "{{ kubectl_version_ret.stdout.split('\n') | list }}"
+


### PR DESCRIPTION
/cc @zexi

## 这个 PR 实现什么功能/修复什么问题:

* 解决ansible-core 2.14 不允许在assert里使用内嵌变量展开的问题。
* 见[官网文档](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_core_2.14.html)

## 是否需要 backport 到之前的 release 分支:

* release/3.10
* release/3.11