### PR TITLE
Automated cherry pick of #1229: fix(backup): 备份失败时，删除以时间戳结尾的空备份路径

### DIFF
--- a/onecloud/roles/utils/auto-backup-services/files/db_backup.sh
+++ b/onecloud/roles/utils/auto-backup-services/files/db_backup.sh
@@ -77,6 +77,10 @@ check_backup_disk() {
     if [ "$disk_usage" -gt $MAX_DISK_PERCENTAGE ]; then
         __info "$BKUP_PATH is on disk $disk, usage:$disk_usage%, too high to continue backup."
         __info "Allowed maximum disk usage: $MAX_DISK_PERCENTAGE."
+        # only delete backup path when it is empty and ends with timestamp like 20240506-163855
+        if [ -z "$(ls -A $BKUP_PATH)" ] && [[ "$BKUP_PATH" =~ [0-9]{8}-[0-9]{6}$ ]]; then
+            rm -rf "$BKUP_PATH"
+        fi
         exit 1
     fi
     __info "Backup Disk: $disk; Used: $disk_usage%"


### PR DESCRIPTION
Cherry pick of #1229 on release/3.10.

#1229: fix(backup): 备份失败时，删除以时间戳结尾的空备份路径