### PR TITLE
fix(lbagent): 添加lbagent节点时debian系列不启动openvswitch服务

### DIFF
--- a/onecloud/roles/worker-node/lbagent/tasks/main.yml
+++ b/onecloud/roles/worker-node/lbagent/tasks/main.yml
@@ -16,6 +16,7 @@
     src: lbagent.conf.j2
     mode: '0755'
 
+# this service can not be enabled on ubunt/debian
 - name: enable openvswitch
   service:
     name: "{{ item }}"
@@ -23,6 +24,8 @@
     state: started
   loop:
   - openvswitch
+  when:
+  - ansible_os_family != 'Debian'
 
 - name: add label onecloud.yunion.io/lbagent=enable to {{ k8s_controlplane_host }}
   shell: KUBECONFIG=/etc/kubernetes/admin.conf kubectl label node "{{ ansible_hostname }}" onecloud.yunion.io/lbagent=enable


### PR DESCRIPTION
/cc @zexi

## 这个 PR 实现什么功能/修复什么问题:

* 添加lbagent节点时debian系列不启动openvswitch服务
## 是否需要 backport 到之前的 release 分支:

* release/3.10
* release/3.11
* release/3.12 