### PR TITLE
在 centos 之外的 os 上不安装kmod-openvswith软件包

### DIFF
--- a/onecloud/roles/utils/detect-os/vars/almalinux-8.yml
+++ b/onecloud/roles/utils/detect-os/vars/almalinux-8.yml
@@ -24,7 +24,6 @@ common_packages:
     - jq
     - keyutils
     - kmod
-    - kmod-openvswitch
     - libaio
     - libbasicobjects
     - libcollection

--- a/onecloud/roles/utils/detect-os/vars/anolis_os.yml
+++ b/onecloud/roles/utils/detect-os/vars/anolis_os.yml
@@ -23,7 +23,6 @@ common_packages:
     - jq
     - keyutils
     - kmod
-    - kmod-openvswitch
     - libaio
     - libbasicobjects
     - libcollection

--- a/onecloud/roles/utils/detect-os/vars/centos-8.yml
+++ b/onecloud/roles/utils/detect-os/vars/centos-8.yml
@@ -25,7 +25,6 @@ common_packages:
     - jq
     - keyutils
     - kmod
-    - kmod-openvswitch
     - libaio
     - libbasicobjects
     - libcollection

--- a/onecloud/roles/utils/detect-os/vars/kylin_linux_advanced_server-v10.aarch64.yml
+++ b/onecloud/roles/utils/detect-os/vars/kylin_linux_advanced_server-v10.aarch64.yml
@@ -25,7 +25,6 @@ common_packages:
   - jq
   - keyutils
   - kmod
-  - kmod-openvswitch
   - kubeadm-1.15.12-0
   - kubectl-1.15.12-0
   - kubelet-1.15.12-0

--- a/onecloud/roles/utils/detect-os/vars/kylin_linux_advanced_server-v10.x86_64.yml
+++ b/onecloud/roles/utils/detect-os/vars/kylin_linux_advanced_server-v10.x86_64.yml
@@ -25,7 +25,6 @@ common_packages:
   - jq
   - keyutils
   - kmod
-  - kmod-openvswitch
   - kubeadm-1.15.12-0
   - kubectl-1.15.12-0
   - kubelet-1.15.12-0

--- a/onecloud/roles/utils/detect-os/vars/opencloudos-8.yml
+++ b/onecloud/roles/utils/detect-os/vars/opencloudos-8.yml
@@ -25,7 +25,6 @@ common_packages:
     - jq
     - keyutils
     - kmod
-    - kmod-openvswitch
     - libaio
     - libbasicobjects
     - libcollection

--- a/onecloud/roles/utils/detect-os/vars/openeuler-aarch64.yml
+++ b/onecloud/roles/utils/detect-os/vars/openeuler-aarch64.yml
@@ -25,7 +25,6 @@ common_packages:
   - jq
   - keyutils
   - kmod
-  - kmod-openvswitch
   - libbasicobjects
   - libcollection
   - libini_config

--- a/onecloud/roles/utils/detect-os/vars/openeuler-x86_64.yml
+++ b/onecloud/roles/utils/detect-os/vars/openeuler-x86_64.yml
@@ -25,7 +25,6 @@ common_packages:
     - jq
     - keyutils
     - kmod
-    - kmod-openvswitch
     - libbasicobjects
     - libcollection
     - libini_config

--- a/onecloud/roles/utils/detect-os/vars/rocky-8.yml
+++ b/onecloud/roles/utils/detect-os/vars/rocky-8.yml
@@ -25,7 +25,6 @@ common_packages:
     - jq
     - keyutils
     - kmod
-    - kmod-openvswitch
     - libaio
     - libbasicobjects
     - libcollection

--- a/onecloud/roles/utils/detect-os/vars/uniontech-kongzi.yml
+++ b/onecloud/roles/utils/detect-os/vars/uniontech-kongzi.yml
@@ -28,7 +28,6 @@ common_packages:
     - jq
     - keyutils
     - kmod
-    - kmod-openvswitch
     - kubeadm-1.15.12-0
     - kubectl-1.15.12-0
     - kubelet-1.15.12-0


### PR DESCRIPTION
/cc @zexi

## 这个 PR 实现什么功能/修复什么问题:

* 在 centos 之外的 os 上不安装kmod-openvswith软件包

## 是否需要 backport 到之前的 release 分支:

* release/3.9
* release/3.10
* release/3.11
* release/3.12