### PR TITLE
Automated cherry pick of #1251: 在 centos 之外的 os 上不安装kmod-openvswith软件包

### DIFF
--- a/onecloud/roles/utils/detect-os/vars/almalinux-8.yml
+++ b/onecloud/roles/utils/detect-os/vars/almalinux-8.yml
@@ -26,7 +26,6 @@ common_packages:
     - jq
     - keyutils
     - kmod
-    - kmod-openvswitch
     - kubeadm-1.15.12-0
     - kubectl-1.15.12-0
     - kubelet-1.15.12-0

--- a/onecloud/roles/utils/detect-os/vars/kylin_linux_advanced_server-v10.aarch64.yml
+++ b/onecloud/roles/utils/detect-os/vars/kylin_linux_advanced_server-v10.aarch64.yml
@@ -25,7 +25,6 @@ common_packages:
   - jq
   - keyutils
   - kmod
-  - kmod-openvswitch
   - kubeadm-1.15.12-0
   - kubectl-1.15.12-0
   - kubelet-1.15.12-0

--- a/onecloud/roles/utils/detect-os/vars/kylin_linux_advanced_server-v10.x86_64.yml
+++ b/onecloud/roles/utils/detect-os/vars/kylin_linux_advanced_server-v10.x86_64.yml
@@ -25,7 +25,6 @@ common_packages:
   - jq
   - keyutils
   - kmod
-  - kmod-openvswitch
   - kubeadm-1.15.12-0
   - kubectl-1.15.12-0
   - kubelet-1.15.12-0

--- a/onecloud/roles/utils/detect-os/vars/opencloudos-8.yml
+++ b/onecloud/roles/utils/detect-os/vars/opencloudos-8.yml
@@ -27,7 +27,6 @@ common_packages:
     - jq
     - keyutils
     - kmod
-    - kmod-openvswitch
     - kubeadm-1.15.12-0
     - kubectl-1.15.12-0
     - kubelet-1.15.12-0

--- a/onecloud/roles/utils/detect-os/vars/openeuler-x86_64.yml
+++ b/onecloud/roles/utils/detect-os/vars/openeuler-x86_64.yml
@@ -25,7 +25,6 @@ common_packages:
     - jq
     - keyutils
     - kmod
-    - kmod-openvswitch
     - libbasicobjects
     - libcollection
     - libini_config

--- a/onecloud/roles/utils/detect-os/vars/rocky-8.yml
+++ b/onecloud/roles/utils/detect-os/vars/rocky-8.yml
@@ -27,7 +27,6 @@ common_packages:
     - jq
     - keyutils
     - kmod
-    - kmod-openvswitch
     - kubeadm-1.15.12-0
     - kubectl-1.15.12-0
     - kubelet-1.15.12-0

--- a/onecloud/roles/utils/detect-os/vars/uniontech-kongzi.yml
+++ b/onecloud/roles/utils/detect-os/vars/uniontech-kongzi.yml
@@ -28,7 +28,6 @@ common_packages:
     - jq
     - keyutils
     - kmod
-    - kmod-openvswitch
     - kubeadm-1.15.12-0
     - kubectl-1.15.12-0
     - kubelet-1.15.12-0


### PR DESCRIPTION
Cherry pick of #1251 on release/3.12.

#1251: 在 centos 之外的 os 上不安装kmod-openvswith软件包