### PR TITLE
addnode: set host_networks if missing

### DIFF
--- a/onecloud/roles/master-node/tasks/k8s.yml
+++ b/onecloud/roles/master-node/tasks/k8s.yml
@@ -72,6 +72,12 @@
     when:
       node_ip is defined
 
+  # define var host_networks if not set.
+  - name: Set node_interface_name
+    include_role:
+      name: utils/set-hostnetworks
+    when: host_networks is undefined or host_networks == ''
+
   - name: construct host network args
     set_fact:
       join_args: "{{ join_args }} --host-networks {{ host_networks }} "

--- a/onecloud/roles/utils/host-service/tasks/main.yml
+++ b/onecloud/roles/utils/host-service/tasks/main.yml
@@ -1,14 +1,6 @@
-- block:
-
-  - name: Set node_interface_name
-    include_role:
-      name: utils/fetch-node-interface
-
-  - name: Set host_networks to {{ node_interface_name }}/br0/{{ node_ip }}
-    set_fact:
-      host_networks: '{{ node_interface_name }}/br0/{{ node_ip }}'
-
-  when: host_networks is undefined or host_networks == ''
+- name: Set node_interface_name
+  include_role:
+    name: utils/set-hostnetworks
 
 - name: Set host_enable_hugepage to true
   set_fact:

--- a/onecloud/roles/utils/set-hostnetworks/tasks/main.yml
+++ b/onecloud/roles/utils/set-hostnetworks/tasks/main.yml
@@ -1,0 +1,11 @@
+- block:
+
+  - name: Set node_interface_name
+    include_role:
+      name: utils/fetch-node-interface
+
+  - name: Set host_networks to {{ node_interface_name }}/br0/{{ node_ip }}
+    set_fact:
+      host_networks: '{{ node_interface_name }}/br0/{{ node_ip }}'
+
+  when: host_networks is undefined or host_networks == ''

--- a/onecloud/roles/worker-node/tasks/k8s.yml
+++ b/onecloud/roles/worker-node/tasks/k8s.yml
@@ -49,6 +49,12 @@
     when:
       node_ip is defined
 
+  # define var host_networks if not set.
+  - name: Set node_interface_name
+    include_role:
+      name: utils/set-hostnetworks
+    when: host_networks is undefined or host_networks == ''
+
   - name: construct host network args
     set_fact:
       join_args: "{{ join_args }} --host-networks {{ host_networks }} "
@@ -84,3 +90,4 @@
 - name: Include utils/k8s/kubelet/extra-args tasks
   include_role:
     name: utils/k8s/kubelet/extra-args
+


### PR DESCRIPTION
/cc @zexi

## 这个 PR 实现什么功能/修复什么问题:

* 添加节点时如果 host_networks为空则赋值

## 是否需要 backport 到之前的 release 分支:

* release/3.10
* release/3.11
* release/3.12