### PR TITLE
addnode: set host_networks if missing 312

### DIFF
--- a/onecloud/roles/master-node/tasks/main.yml
+++ b/onecloud/roles/master-node/tasks/main.yml
@@ -99,6 +99,12 @@
     when:
       node_ip is defined
 
+  # define var host_networks if not set.
+  - name: Set node_interface_name
+    include_role:
+      name: utils/set-hostnetworks
+    when: host_networks is undefined or host_networks == ''
+
   - name: construct host network args
     set_fact:
       join_args: "{{ join_args }} --host-networks {{ host_networks }} "

--- a/onecloud/roles/utils/fetch-node-interface/tasks/main.yml
+++ b/onecloud/roles/utils/fetch-node-interface/tasks/main.yml
@@ -1,0 +1,19 @@
+- name: Run `ip -4 -brief address show`
+  shell: |
+    ip -4 -brief address show | grep {{ node_ip }}/ | awk '{print $1}'
+  register: NODE_INTERFACE
+
+- name: Set node_interface_name to {{ NODE_INTERFACE.stdout }}
+  set_fact:
+    node_interface_name: "{{ NODE_INTERFACE.stdout_lines[0] }}"
+
+- block:
+  - name: Find the physical interface on br0
+    shell: |
+      ovs-vsctl list-ifaces br0 | head -n 1
+    register: BR0_PHY_NIC
+
+  - name: Update node_interface_name when br0 is existing
+    set_fact:
+      node_interface_name: "{{ BR0_PHY_NIC.stdout_lines[0] }}"
+  when: node_interface_name == 'br0'

--- a/onecloud/roles/utils/set-hostnetworks/tasks/main.yml
+++ b/onecloud/roles/utils/set-hostnetworks/tasks/main.yml
@@ -1,0 +1,11 @@
+- block:
+
+  - name: Configure host service
+    include_role:
+      name: utils/fetch-node-interface
+
+  - name: Set host_networks to {{ node_interface_name }}/br0/{{ node_ip }}
+    set_fact:
+      host_networks: '{{ node_interface_name }}/br0/{{ node_ip }}'
+
+  when: host_networks is undefined or host_networks == ''

--- a/onecloud/roles/worker-node/tasks/main.yml
+++ b/onecloud/roles/worker-node/tasks/main.yml
@@ -86,6 +86,12 @@
     when:
       node_ip is defined
 
+  # define var host_networks if not set.
+  - name: Configure host service
+    include_role:
+      name: utils/set-hostnetworks
+    when: host_networks is undefined or host_networks == ''
+
   - name: construct host network args
     set_fact:
       join_args: "{{ join_args }} --host-networks {{ host_networks }} "


### PR DESCRIPTION
/cc @zexi

## 这个 PR 实现什么功能/修复什么问题:

* 添加节点时如果 host_networks为空则赋值

## 是否需要 backport 到之前的 release 分支:

* release/3.10
* release/3.11
