### PR TITLE
fix: change apiserver args setting order

### DIFF
--- a/onecloud/install-cluster.yml
+++ b/onecloud/install-cluster.yml
@@ -77,6 +77,10 @@
   tags:
     - eip
 
+- hosts: primary_master_node:master_nodes
+  roles:
+    - utils/k8s/apiserver/args
+
 - hosts: primary_master_node:master_nodes:worker_nodes
   roles:
     - primary-master-node/reboot

--- a/onecloud/roles/utils/k8s/apiserver/args/tasks/main.yml
+++ b/onecloud/roles/utils/k8s/apiserver/args/tasks/main.yml
@@ -1,0 +1,11 @@
+- name: Check if kube-apiserver.yaml exists
+  stat:
+    path: /etc/kubernetes/manifests/kube-apiserver.yaml
+  register: kube_apiserver_yaml_stat
+
+- name: Check and insert TLS cipher suite line in kube-apiserver.yaml
+  ansible.builtin.lineinfile:
+    path: /etc/kubernetes/manifests/kube-apiserver.yaml
+    insertafter: '    - --tls-private-key-file=/etc/kubernetes/pki/apiserver.key'
+    line: '    - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA'
+  when: kube_apiserver_yaml_stat.stat.exists

--- a/onecloud/roles/utils/k8s/kubelet/extra-args/tasks/main.yml
+++ b/onecloud/roles/utils/k8s/kubelet/extra-args/tasks/main.yml
@@ -12,18 +12,6 @@
       dest: /etc/sysconfig/kubelet
     become: true
 
-  - name: Check if kube-apiserver.yaml exists
-    stat:
-      path: /etc/kubernetes/manifests/kube-apiserver.yaml
-    register: kube_apiserver_yaml_stat
-
-  - name: Check and insert TLS cipher suite line in kube-apiserver.yaml
-    ansible.builtin.lineinfile:
-      path: /etc/kubernetes/manifests/kube-apiserver.yaml
-      insertafter: '    - --tls-private-key-file=/etc/kubernetes/pki/apiserver.key'
-      line: '    - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA'
-    when: kube_apiserver_yaml_stat.stat.exists
-
   - name: "Restart kubelet"
     systemd:
       name: kubelet

--- a/onecloud/upgrade-cluster.yml
+++ b/onecloud/upgrade-cluster.yml
@@ -16,6 +16,10 @@
   roles:
     - { role: upgrade/worker_nodes }
 
+- hosts: primary_master_node:master_nodes
+  roles:
+    - { role: utils/k8s/apiserver/args }
+
 - hosts: primary_master_node:master_nodes:worker_nodes
   roles:
     - { role: utils/gpu-init }


### PR DESCRIPTION
修复 kube-apiserver 因为设置额外参数，中途重启，导致后续 kubectl 相关步骤可能出现失败的问题
<img width="465" alt="image" src="https://github.com/yunionio/ocboot/assets/10767027/60f3e770-d2f6-4c56-ab1a-7a5fdfd5166c">
