### PR TITLE
fix(ocboot): update operator image for k3s and use IMAGE_REPOSITORY env

### DIFF
--- a/ocboot.sh
+++ b/ocboot.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-REGISTRY=${REGISTRY:-registry.cn-beijing.aliyuncs.com/yunionio}
+IMAGE_REPOSITORY=${IMAGE_REPOSITORY:-registry.cn-beijing.aliyuncs.com/yunionio}
 VERSION=${VERSION:-v4-k3s.4}
-OCBOOT_IMAGE="$REGISTRY/ocboot:$VERSION"
+OCBOOT_IMAGE="$IMAGE_REPOSITORY/ocboot:$VERSION"
 
 CUR_DIR="$(pwd)"
 CONTAINER_NAME="buildah-ocboot"

--- a/onecloud/roles/primary-master-node/setup_cloud/templates/onecloud-manifests.yaml.j2
+++ b/onecloud/roles/primary-master-node/setup_cloud/templates/onecloud-manifests.yaml.j2
@@ -146,8 +146,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: onecloud-operator
-        # image: {{ image_repository }}/onecloud-operator:{{ onecloud_version }}
-        image: registry.cn-beijing.aliyuncs.com/yunionio/onecloud-operator:k3s-0118.0
+        image: {{ image_repository }}/onecloud-operator:{{ onecloud_version }}
         imagePullPolicy: IfNotPresent
         command:
         - "/bin/onecloud-controller-manager"

--- a/scripts/install-buildah.sh
+++ b/scripts/install-buildah.sh
@@ -26,15 +26,15 @@ supported_os=(
     "openEuler 22.03 aarch64"
     "OpenCloudOS 8.8 x86_64"
     "Rocky Linux 8.9 x86_64"
-    "Ubuntu 22.04.2 LTS x86_64"
-    "Ubuntu 22.04.2 LTS aarch64"
+    "Ubuntu 22.04.* LTS x86_64"
+    "Ubuntu 22.04.* LTS aarch64"
 )
 
 is_supported() {
     local s
     s="$(get_name_version)"
     for i in "${supported_os[@]}"; do
-        if [[ "$i" == "$s" ]]; then
+        if echo "$s" | grep "$i"; then
             return 0
         fi
     done


### PR DESCRIPTION
- 修复 ubuntu 22.04.3 不能使用 scirpts/install-buildah.sh 安装 buildah 的问题
- 统一使用 IMAGE_REPOSITORY 作为镜像仓库环境变量
- 更新 k3s 使用的 operator 镜像