### PR TITLE
Automated cherry pick of #1347: fix: support ansible_become for sudo user globally

### DIFF
--- a/lib/cluster.py
+++ b/lib/cluster.py
@@ -230,6 +230,8 @@ class ansibleHost(object):
             self.user,
             self.port,
             self.port)
+        if self.user != 'root':
+            config += " ansible_become=yes"
         if self.bastion_host:
             config += " ansible_ssh_common_args='%s'" % self.bastion_host.to_option()
         return config

--- a/lib/ocboot.py
+++ b/lib/ocboot.py
@@ -254,6 +254,8 @@ class Node(object):
             'ansible_user': self.user,
             'ansible_port': self.port,
         }
+        if self.user != 'root':
+            vars['ansible_become'] = 'yes'
         if self.bastion_host:
             vars['ansible_ssh_common_args'] = self.bastion_host.to_option()
         if self.host != "127.0.0.1":


### PR DESCRIPTION
Cherry pick of #1347 on master.

#1347: fix: support ansible_become for sudo user globally