### PR TITLE
feat: support host_networks and disk_paths option for add-node

### DIFF
--- a/lib/add_node.py
+++ b/lib/add_node.py
@@ -8,7 +8,7 @@ from .parser import inject_add_nodes_runtime_options
 class AddWorkerNodeService(AddNodeService):
 
     def inject_options(self, parser):
-        super(AddNodeService, self).inject_options(parser)
+        super(AddWorkerNodeService, self).inject_options(parser)
         inject_add_nodes_runtime_options(parser)
 
     def do_action(self, args):
@@ -25,7 +25,9 @@ class AddWorkerNodeService(AddNodeService):
                                 args.ssh_port,
                                 args.ssh_node_port,
                                 enable_host_on_vm=True,
-                                runtime=args.runtime)
+                                runtime=args.runtime,
+                                host_networks=args.host_networks,
+                                disk_paths=args.disk_paths)
         config.run()
 
 

--- a/lib/cmd.py
+++ b/lib/cmd.py
@@ -94,7 +94,7 @@ def run_ansible_playbook(hosts_f, playbook_f, debug_level=0, vars=None):
     cmd = ["ansible-playbook"]
 
     if vars:
-        vars_f = "/tmp/oc_vars.yml"
+        vars_f = "./oc_vars.yml"
         with open(vars_f, 'w') as f:
             f.write(utils.to_yaml(vars))
         cmd.extend(["-e", "@%s" % vars_f])

--- a/lib/parser.py
+++ b/lib/parser.py
@@ -82,6 +82,18 @@ def inject_add_hostagent_options(parser):
                         action="store_true", default=False,
                         help="enable kvm host service inside virtual machine")
 
+    parser.add_argument("--host-network",
+                        nargs="*",
+                        action="extend",
+                        dest="host_networks",
+                        help="networks option of /etc/yunion/host.conf")
+
+    parser.add_argument("--disk-path",
+                        nargs="*",
+                        action="extend",
+                        dest="disk_paths",
+                        help="local_image_path of /etc/yunion/host.conf")
+
 
 def inject_add_nodes_runtime_options(parser):
     parser.add_argument("--runtime",
@@ -89,6 +101,7 @@ def inject_add_nodes_runtime_options(parser):
                         default=consts.RUNTIME_QEMU,
                         choices=[consts.RUNTIME_QEMU, consts.RUNTIME_CONTAINERD],
                         help="select runtime type when adding node. default: qemu")
+
 
 def inject_auto_backup_options(parser):
     parser.add_argument(

--- a/lib/service.py
+++ b/lib/service.py
@@ -3,7 +3,7 @@
 
 from __future__ import unicode_literals
 
-from .ocboot import KEY_ENABLE_CONTAINERD, KEY_IMAGE_REPOSITORY, NodeConfig, Config
+from .ocboot import KEY_DISK_PATHS, KEY_ENABLE_CONTAINERD, KEY_HOST_NETWORKS, KEY_IMAGE_REPOSITORY, NodeConfig, Config
 from .cmd import run_ansible_playbook
 from .ansible import get_inventory_config
 from .parser import inject_add_hostagent_options
@@ -187,6 +187,8 @@ class AddNodesConfig(object):
             'controlplane_ssh_port': controlplane_ssh_port,
             'enable_lbagent': enable_lbagent,
             KEY_ENABLE_CONTAINERD: self.enable_containerd,
+            KEY_HOST_NETWORKS: kwargs.get(KEY_HOST_NETWORKS, None),
+            KEY_DISK_PATHS: kwargs.get(KEY_DISK_PATHS, None),
         }
         (repo, is_insecure) = cluster.get_repository()
         if is_insecure:
@@ -199,7 +201,7 @@ class AddNodesConfig(object):
     def run(self):
         inventory_content = ansible.get_inventory_config(self.worker_config)
         yaml_content = utils.to_yaml(inventory_content)
-        filepath = '/tmp/cluster_add_node_inventory.yml'
+        filepath = './cluster_add_node_inventory.yml'
         with open(filepath, 'w') as f:
             f.write(yaml_content)
         # start run upgrade playbook

--- a/onecloud/roles/utils/host-service/defaults/main.yml
+++ b/onecloud/roles/utils/host-service/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 host_enable_hugepage: false
+disk_paths:
+- /opt/cloud/workspace/disks

--- a/onecloud/roles/utils/host-service/templates/host.conf.j2
+++ b/onecloud/roles/utils/host-service/templates/host.conf.j2
@@ -71,13 +71,17 @@ is_slave_node: false
 kubelet_run_directory: /var/lib/kubelet
 linux_default_root_user: true
 local_image_path:
-- /opt/cloud/workspace/disks
+{% for disk_path in disk_paths %}
+- {{ disk_path }}
+{% endfor %}
 log_level: info
 log_verbose_level: 0
 manage_ntp_configuration: true
 max_reserved_memory: 10240
 networks:
-- {{ host_networks }}
+{% for network in host_networks %}
+- {{ network }}
+{% endfor %}
 non_default_domain_projects: false
 notify_admin_users:
 - sysadmin

--- a/onecloud/roles/utils/set-hostnetworks/tasks/main.yml
+++ b/onecloud/roles/utils/set-hostnetworks/tasks/main.yml
@@ -6,6 +6,6 @@
 
   - name: Set host_networks to {{ node_interface_name }}/br0/{{ node_ip }}
     set_fact:
-      host_networks: '{{ node_interface_name }}/br0/{{ node_ip }}'
+      host_networks: "['{{ node_interface_name }}/br0/{{ node_ip }}']"
 
   when: host_networks is undefined or host_networks == ''


### PR DESCRIPTION
用法：
```bash
./ocboot.sh add-node 192.168.0.240 192.168.0.250  \
    --host-network eth0/br0/bcast0 
    --host-network eth1/br1/bcast1 
    --disk-path /opt/cloud/workspace/disk2
    --disk-path /opt/cloud/workspace/disk3
```