### PR TITLE
🐛 fix: Modify the lbagent tasks Ansible playbook file to fix the error cau…

### DIFF
--- a/onecloud/roles/worker-node/lbagent/tasks/main.yml
+++ b/onecloud/roles/worker-node/lbagent/tasks/main.yml
@@ -10,6 +10,12 @@
   set_fact:
     lbagent_access_ip: "{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}"
 
+- name: ensure that the directory /etc/yunion/ exists.
+  file:
+    path: /etc/yunion/
+    state: directory
+    mode: '0755'
+
 - name: copy lbagent configuration file
   template:
     dest: /etc/yunion/lbagent.conf


### PR DESCRIPTION
Modify the lbagent tasks Ansible playbook file to fix the error caused by the non-existence of the added node directory /etc/yunion/.

After this error occurs, you can only remove the k3s component from the added node and uninstall k3s. Then, manually create the /etc/yunion/ directory and re-execute the command on the manager node: /ocboot.sh add-lbagent <ip_of_master_node> <ip_of_lbagent_node>.