### PR TITLE
Automated cherry pick of #1436: fix: disable cgorupv2 only for ubuntu 22.x, 24.x, debian 11, 12

### DIFF
--- a/onecloud/roles/common/tasks/os/debian_family.yml
+++ b/onecloud/roles/common/tasks/os/debian_family.yml
@@ -19,6 +19,9 @@
 
 - name: Unified Cgroup Hierarchy
   include_tasks: utils/unified_cgroup_hierarchy.yml
+  when:
+    - ansible_distribution in ["Debian", "Ubuntu"]
+    - ansible_distribution_major_version in ["11", "12", "13", "22", "24"]
 
 - name: install common packages via loop for Debian Family
   package:


### PR DESCRIPTION
Cherry pick of #1436 on release/4.0.

#1436: fix: disable cgorupv2 only for ubuntu 22.x, 24.x, debian 11, 12