### PR TITLE
install-buildah.sh: completing the openEuler 24.03  LTS-SP1 support

### DIFF
--- a/scripts/install-buildah.sh
+++ b/scripts/install-buildah.sh
@@ -24,6 +24,8 @@ supported_os=(
     "Debian GNU/Linux 11 aarch64"
     "openEuler 22.03 x86_64"
     "openEuler 22.03 aarch64"
+    "openEuler 24.03 x86_64"
+    "openEuler 24.03 aarch64"
     "OpenCloudOS 8.8 x86_64"
     "Rocky Linux 8.9 x86_64"
     "Ubuntu 20.04.* LTS x86_64"


### PR DESCRIPTION
Because of this `ocboot.sh run.py` or `ocboot.sh install` will break before ansible in clean minimum install of openEuler 24.03 LTS-SP1