### PR TITLE
Automated cherry pick of #1447: ocboot.sh: add support for non-root user for no-root password installation

### DIFF
--- a/ocboot.sh
+++ b/ocboot.sh
@@ -72,10 +72,15 @@ if [[ "$1" == "run.py" ]]; then
     origin_args="$ROOT_DIR/$origin_args"
 fi
 
-buildah run --isolation chroot --user $(whoami) \
+buildah run --isolation chroot --user $(id -u):$(id -g) \
     -t "${buildah_extra_args[@]}" \
     --net=host \
+    -e "HOME=$HOME" \
+    -v "$(mktemp -d):$HOME/.ansible" \
     -v "$HOME/.ssh:$HOME/.ssh" \
+    -v "$HOME/.kube:$HOME/.kube" \
+    -v "/etc/passwd:/etc/passwd:ro" \
+    -v "/etc/group:/etc/group:ro" \
     -v "$(pwd):$ROOT_DIR" \
     -v "$(pwd)/airgap_assets/k3s-install.sh:/airgap_assets/k3s-install.sh:ro" \
     "$CONTAINER_NAME" $CMD $origin_args $cmd_extra_args

--- a/ocboot.sh
+++ b/ocboot.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+shopt -s expand_aliases
+
 set -e
 
 DEFAULT_REPO=registry.cn-beijing.aliyuncs.com/yunionio

--- a/ocboot.sh
+++ b/ocboot.sh
@@ -10,6 +10,8 @@ OCBOOT_IMAGE="$IMAGE_REPOSITORY/ocboot:$VERSION"
 CUR_DIR="$(pwd)"
 CONTAINER_NAME="buildah-ocboot"
 
+alias buildah="sudo buildah"
+
 ensure_buildah() {
     if ! [ -x "$(command -v buildah)" ]; then
         echo "Installing buildah ..."
@@ -76,6 +78,7 @@ buildah run --isolation chroot --user $(id -u):$(id -g) \
     -t "${buildah_extra_args[@]}" \
     --net=host \
     -e "HOME=$HOME" \
+    -v "$(mktemp -d):$HOME/.ansible" \
     -v "$HOME/.ssh:$HOME/.ssh" \
     -v "$HOME/.kube:$HOME/.kube" \
     -v "/etc/passwd:/etc/passwd:ro" \

--- a/ocboot.sh
+++ b/ocboot.sh
@@ -76,7 +76,6 @@ buildah run --isolation chroot --user $(id -u):$(id -g) \
     -t "${buildah_extra_args[@]}" \
     --net=host \
     -e "HOME=$HOME" \
-    -v "$(mktemp -d):$HOME/.ansible" \
     -v "$HOME/.ssh:$HOME/.ssh" \
     -v "$HOME/.kube:$HOME/.kube" \
     -v "/etc/passwd:/etc/passwd:ro" \


### PR DESCRIPTION
Cherry pick of #1447 on release/4.0.

#1447: ocboot.sh: add support for non-root user for no-root password installation