### PR TITLE
Automated cherry pick of #1457: fix: ensure $HOME/.kube dir existed

### DIFF
--- a/ocboot.sh
+++ b/ocboot.sh
@@ -76,6 +76,8 @@ if [[ "$1" == "run.py" ]]; then
     origin_args="$ROOT_DIR/$origin_args"
 fi
 
+mkdir -p "$HOME/.kube"
+
 buildah run --isolation chroot --user $(id -u):$(id -g) \
     -t "${buildah_extra_args[@]}" \
     --net=host \


### PR DESCRIPTION
Cherry pick of #1457 on release/4.0.

#1457: fix: ensure $HOME/.kube dir existed