### PR TITLE
Automated cherry pick of #1470: fix(openeuler-x86_64): add python3-libselinux package

### DIFF
--- a/onecloud/roles/utils/detect-os/vars/openeuler-x86_64.yml
+++ b/onecloud/roles/utils/detect-os/vars/openeuler-x86_64.yml
@@ -19,6 +19,7 @@ common_packages:
     - parallel
     - rsync
     - tcpdump
+    - python3-libselinux
     - "{{ yunion_qemu_package }}"
 
 common_services:


### PR DESCRIPTION
Cherry pick of #1470 on release/4.0.

#1470: fix(openeuler-x86_64): add python3-libselinux package