### PR TITLE
Automated cherry pick of #1488: fix: update keepalived_version_tag to v2.0.29 to support ipv6

### DIFF
--- a/lib/ocboot.py
+++ b/lib/ocboot.py
@@ -454,7 +454,7 @@ class OnecloudConfig(object):
         self.high_availability_vip = None
         self.keepalived_version_tag = None
         self.keepalived_password = None
-        default_keepalived_version_tag = 'v2.0.28' if is_using_k3s() else 'v2.0.25'
+        default_keepalived_version_tag = 'v2.0.29' if is_using_k3s() else 'v2.0.25'
         if self.high_availability:
             self.high_availability_vip = self.controlplane_host
             self.keepalived_password = base64.b64encode(self.high_availability_vip.encode('ascii'))[0:8].decode()


### PR DESCRIPTION
Cherry pick of #1488 on master.

#1488: fix: update keepalived_version_tag to v2.0.29 to support ipv6