### PR TITLE
Automated cherry pick of #1611: fix(common): add default for docker_registry_mirrors and docker_insecure_registries

### DIFF
--- a/onecloud/roles/common/templates/daemon.json.j2
+++ b/onecloud/roles/common/templates/daemon.json.j2
@@ -10,10 +10,10 @@
   "log-opts": {
       "max-size": "100m"
    },
-{% if docker_registry_mirrors|length > 0 %}
+{% if docker_registry_mirrors|default([])|length > 0 %}
   "registry-mirrors": {{ docker_registry_mirrors|to_json }},
 {% endif %}
-{% if docker_insecure_registries|length > 0 %}
+{% if docker_insecure_registries|default([])|length > 0 %}
   "insecure-registries": {{ docker_insecure_registries|to_json }},
 {% endif %}
   "live-restore": true


### PR DESCRIPTION
Cherry pick of #1611 on release/4.0.

#1611: fix(common): add default for docker_registry_mirrors and docker_insecure_registries