### PR TITLE
fix(setup-ai-env): installer path accessibility and OS-specific comma…

### DIFF
--- a/ocboot.sh
+++ b/ocboot.sh
@@ -79,6 +79,28 @@ fi
 
 mkdir -p "$HOME/.kube"
 
+# Parse --nvidia-driver-installer-path and --cuda-installer-path from args and
+# add bind-mounts so the installer files are accessible inside the container at
+# their original absolute paths.
+extra_installer_volumes=()
+prev_arg=""
+declare -A mounted_installer_dirs
+for arg in "$@"; do
+    case "$prev_arg" in
+        --nvidia-driver-installer-path|--cuda-installer-path)
+            # Only handle absolute paths that are not already under $(pwd)
+            if [[ "$arg" == /* ]] && [[ "${arg#$(pwd)/}" == "$arg" ]]; then
+                _dir="$(dirname "$arg")"
+                if [[ -z "${mounted_installer_dirs[$_dir]+x}" ]]; then
+                    extra_installer_volumes+=(-v "$_dir:$_dir:ro")
+                    mounted_installer_dirs[$_dir]=1
+                fi
+            fi
+            ;;
+    esac
+    prev_arg="$arg"
+done
+
 buildah run --isolation chroot --user $(id -u):$(id -g) \
     -t "${buildah_extra_args[@]}" \
     --net=host \
@@ -89,4 +111,5 @@ buildah run --isolation chroot --user $(id -u):$(id -g) \
     -v "/etc/group:/etc/group:ro" \
     -v "$(pwd):$ROOT_DIR" \
     -v "$(pwd)/airgap_assets/k3s-install.sh:/airgap_assets/k3s-install.sh:ro" \
+    "${extra_installer_volumes[@]}" \
     "$CONTAINER_NAME" $CMD $origin_args $cmd_extra_args

--- a/onecloud/roles/utils/ai-env/tasks/check-local-files.yml
+++ b/onecloud/roles/utils/ai-env/tasks/check-local-files.yml
@@ -1,25 +1,53 @@
-- name: Check if NVIDIA driver installer exists locally
+- name: Check if NVIDIA driver installer exists on target host
   stat:
     path: "{{ nvidia_driver_installer_path }}"
-  register: nvidia_file_check
-  delegate_to: localhost
-  become: false
+  register: nvidia_remote_file_check
   when: nvidia_driver_installer_path is defined
 
-- name: Fail if NVIDIA driver installer not found
-  fail:
-    msg: "NVIDIA driver installer not found at {{ nvidia_driver_installer_path }}"
-  when: nvidia_driver_installer_path is defined and (not nvidia_file_check.stat.exists | default(false))
+- name: Set flag for NVIDIA installer presence on target host
+  set_fact:
+    nvidia_installer_on_remote: "{{ nvidia_remote_file_check.stat.exists | default(false) }}"
+  when: nvidia_driver_installer_path is defined
 
-- name: Check if CUDA installer exists locally
+- name: Check if NVIDIA driver installer exists locally (control node fallback)
   stat:
-    path: "{{ cuda_installer_path }}"
-  register: cuda_file_check
+    path: "{{ nvidia_driver_installer_path }}"
+  register: nvidia_local_file_check
   delegate_to: localhost
   become: false
+  when: nvidia_driver_installer_path is defined and not (nvidia_installer_on_remote | default(false))
+
+- name: Fail if NVIDIA driver installer not found on target host or locally
+  fail:
+    msg: "NVIDIA driver installer not found at {{ nvidia_driver_installer_path }} on either the target host or the control node"
+  when: >
+    nvidia_driver_installer_path is defined and
+    not (nvidia_installer_on_remote | default(false)) and
+    not (nvidia_local_file_check.stat.exists | default(false))
+
+- name: Check if CUDA installer exists on target host
+  stat:
+    path: "{{ cuda_installer_path }}"
+  register: cuda_remote_file_check
   when: cuda_installer_path is defined
 
-- name: Fail if CUDA installer not found
+- name: Set flag for CUDA installer presence on target host
+  set_fact:
+    cuda_installer_on_remote: "{{ cuda_remote_file_check.stat.exists | default(false) }}"
+  when: cuda_installer_path is defined
+
+- name: Check if CUDA installer exists locally (control node fallback)
+  stat:
+    path: "{{ cuda_installer_path }}"
+  register: cuda_local_file_check
+  delegate_to: localhost
+  become: false
+  when: cuda_installer_path is defined and not (cuda_installer_on_remote | default(false))
+
+- name: Fail if CUDA installer not found on target host or locally
   fail:
-    msg: "CUDA installer not found at {{ cuda_installer_path }}"
-  when: cuda_installer_path is defined and (not cuda_file_check.stat.exists | default(false))
+    msg: "CUDA installer not found at {{ cuda_installer_path }} on either the target host or the control node"
+  when: >
+    cuda_installer_path is defined and
+    not (cuda_installer_on_remote | default(false)) and
+    not (cuda_local_file_check.stat.exists | default(false))

--- a/onecloud/roles/utils/ai-env/tasks/configure-grub.yml
+++ b/onecloud/roles/utils/ai-env/tasks/configure-grub.yml
@@ -12,13 +12,29 @@
   become: true
   when: grub_check.rc != 0
 
-- name: Update GRUB configuration
-  shell: grub2-mkconfig > /boot/efi/EFI/openEuler/grub.cfg
+- name: Detect GRUB config file path (RedHat)
+  shell: |
+    find /boot/efi/EFI -name grub.cfg -maxdepth 2 2>/dev/null | head -1 || echo "/boot/grub2/grub.cfg"
+  register: grub_cfg_path_result
+  changed_when: false
+  become: true
+  when: grub_check.rc != 0 and ansible_os_family == "RedHat"
+
+- name: Update GRUB configuration (RedHat)
+  shell: grub2-mkconfig -o {{ grub_cfg_path_result.stdout | trim }}
   become: true
   args:
     executable: /bin/bash
-  when: grub_check.rc != 0
-  register: grub_update_result
+  when: grub_check.rc != 0 and ansible_os_family == "RedHat"
+  register: grub_update_result_redhat
+
+- name: Update GRUB configuration (Debian)
+  shell: update-grub
+  become: true
+  args:
+    executable: /bin/bash
+  when: grub_check.rc != 0 and ansible_os_family == "Debian"
+  register: grub_update_result_debian
 
 - name: Reboot system after grub update
   reboot:

--- a/onecloud/roles/utils/ai-env/tasks/install-container-toolkit.yml
+++ b/onecloud/roles/utils/ai-env/tasks/install-container-toolkit.yml
@@ -9,20 +9,20 @@
     container_toolkit_installed: "{{ toolkit_check.rc == 0 }}"
 
 - block:
-  - name: Add NVIDIA Container Toolkit repository
+  - name: Add NVIDIA Container Toolkit repository (RedHat)
     copy:
       src: nvidia-container-toolkit.repo
       dest: /etc/yum.repos.d/nvidia-container-toolkit.repo
       mode: '0644'
     become: true
 
-  - name: Enable NVIDIA Container Toolkit experimental repository
+  - name: Enable NVIDIA Container Toolkit experimental repository (RedHat)
     shell: sudo yum-config-manager --enable nvidia-container-toolkit-experimental
     become: true
     args:
       executable: /bin/bash
 
-  - name: Install NVIDIA Container Toolkit
+  - name: Install NVIDIA Container Toolkit (RedHat)
     package:
       name: nvidia-container-toolkit-1.17.8-1
       state: present
@@ -30,4 +30,54 @@
 
   - debug: msg="NVIDIA Container Toolkit installed successfully"
 
-  when: not container_toolkit_installed | default(false)
+  when: not container_toolkit_installed | default(false) and ansible_os_family == "RedHat"
+
+- block:
+  - name: Install curl and gpg prerequisites (Debian)
+    apt:
+      name:
+        - curl
+        - gpg
+      state: present
+      update_cache: yes
+    become: true
+
+  - name: Add NVIDIA Container Toolkit GPG key (Debian)
+    shell: |
+      curl -fsSL https://mirrors.ustc.edu.cn/libnvidia-container/gpgkey | \
+        gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+    become: true
+    args:
+      executable: /bin/bash
+
+  - name: Add NVIDIA Container Toolkit apt repository (Debian)
+    shell: |
+      curl -s -L https://mirrors.ustc.edu.cn/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+        sed 's#deb https://nvidia.github.io#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://mirrors.ustc.edu.cn#g' | \
+        tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+    become: true
+    args:
+      executable: /bin/bash
+
+  - name: Update apt cache (Debian)
+    apt:
+      update_cache: yes
+    become: true
+
+  - name: Install NVIDIA Container Toolkit (Debian)
+    shell: |
+      export NVIDIA_CONTAINER_TOOLKIT_VERSION=1.17.8-1
+      apt install -y \
+        nvidia-container-toolkit=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
+        nvidia-container-toolkit-base=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
+        libnvidia-container-tools=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
+        libnvidia-container1=${NVIDIA_CONTAINER_TOOLKIT_VERSION}
+    become: true
+    args:
+      executable: /bin/bash
+    environment:
+      DEBIAN_FRONTEND: noninteractive
+
+  - debug: msg="NVIDIA Container Toolkit installed successfully"
+
+  when: not container_toolkit_installed | default(false) and ansible_os_family == "Debian"

--- a/onecloud/roles/utils/ai-env/tasks/install-cuda.yml
+++ b/onecloud/roles/utils/ai-env/tasks/install-cuda.yml
@@ -18,6 +18,7 @@
       name: rsync
       state: present
     become: true
+    when: not (cuda_installer_on_remote | default(false))
 
   - name: Copy CUDA installer to remote host using synchronize
     ansible.builtin.synchronize:
@@ -26,12 +27,15 @@
       mode: push
     delegate_to: localhost
     become: false
-    when: cuda_installer_path is defined
+    when: cuda_installer_path is defined and not (cuda_installer_on_remote | default(false))
+
+  - name: Set effective CUDA installer path
+    set_fact:
+      cuda_installer_effective_path: "{{ cuda_installer_path if (cuda_installer_on_remote | default(false)) else '/opt/nvidia/' + cuda_installer }}"
 
   - name: Check CUDA installer help
     shell: |
-      cd /opt/nvidia
-      ./{{ cuda_installer }} --help
+      {{ cuda_installer_effective_path }} --help
     become: true
     args:
       executable: /bin/bash
@@ -50,9 +54,8 @@
 
   - name: Verify CUDA installer file integrity
     shell: |
-      cd /opt/nvidia
-      file ./{{ cuda_installer }}
-      ls -lh ./{{ cuda_installer }}
+      file {{ cuda_installer_effective_path }}
+      ls -lh {{ cuda_installer_effective_path }}
     become: true
     register: cuda_file_check
     changed_when: false
@@ -62,11 +65,11 @@
 
   - name: Install CUDA
     shell: |
-      cd /opt/nvidia
       export TMPDIR=/opt/nvidia/tmp
       export TEMP=/opt/nvidia/tmp
       export TMP=/opt/nvidia/tmp
-      setsid bash -c "./{{ cuda_installer }} --silent --toolkit" < /dev/null > /tmp/cuda_install.log 2>&1 || {
+      chmod +x {{ cuda_installer_effective_path }}
+      setsid bash -c "{{ cuda_installer_effective_path }} --silent --toolkit" < /dev/null > /tmp/cuda_install.log 2>&1 || {
         EXIT_CODE=$?
         cat /tmp/cuda_install.log
         exit $EXIT_CODE

--- a/onecloud/roles/utils/ai-env/tasks/install-nvidia-driver.yml
+++ b/onecloud/roles/utils/ai-env/tasks/install-nvidia-driver.yml
@@ -86,12 +86,27 @@
   become: true
   register: grub_iommu_removed
 
-- name: 重新生成 grub 配置
-  shell: grub2-mkconfig > /boot/efi/EFI/openEuler/grub.cfg
+- name: 检测 GRUB 配置文件路径（RedHat）
+  shell: |
+    find /boot/efi/EFI -name grub.cfg -maxdepth 2 2>/dev/null | head -1 || echo "/boot/grub2/grub.cfg"
+  register: grub_cfg_path_nvidia_driver
+  changed_when: false
+  become: true
+  when: (grub_vfio_removed.changed or grub_iommu_removed.changed) and ansible_os_family == "RedHat"
+
+- name: 重新生成 grub 配置（RedHat）
+  shell: grub2-mkconfig -o {{ grub_cfg_path_nvidia_driver.stdout | trim }}
   become: true
   args:
     executable: /bin/bash
-  when: grub_vfio_removed.changed or grub_iommu_removed.changed
+  when: (grub_vfio_removed.changed or grub_iommu_removed.changed) and ansible_os_family == "RedHat"
+
+- name: 重新生成 grub 配置（Debian）
+  shell: update-grub
+  become: true
+  args:
+    executable: /bin/bash
+  when: (grub_vfio_removed.changed or grub_iommu_removed.changed) and ansible_os_family == "Debian"
 
 - name: 重启系统
   reboot:

--- a/onecloud/roles/utils/ai-env/tasks/install-nvidia-driver.yml
+++ b/onecloud/roles/utils/ai-env/tasks/install-nvidia-driver.yml
@@ -146,6 +146,7 @@
       name: rsync
       state: present
     become: true
+    when: not (nvidia_installer_on_remote | default(false))
 
   - name: Copy NVIDIA driver installer to remote host using synchronize
     ansible.builtin.synchronize:
@@ -154,7 +155,11 @@
       mode: push
     delegate_to: localhost
     become: false
-    when: nvidia_driver_installer_path is defined
+    when: nvidia_driver_installer_path is defined and not (nvidia_installer_on_remote | default(false))
+
+  - name: Set effective NVIDIA driver installer path
+    set_fact:
+      nvidia_installer_effective_path: "{{ nvidia_driver_installer_path if (nvidia_installer_on_remote | default(false)) else '/opt/nvidia/' + nvidia_driver_installer }}"
 
   - name: Find kernel source path
     shell: |
@@ -177,8 +182,8 @@
 
   - name: Install NVIDIA driver with kernel source path
     shell: |
-      cd /opt/nvidia
-      ./{{ nvidia_driver_installer }} --silent --accept-license --no-questions --kernel-source-path={{ kernel_source_path }}
+      chmod +x {{ nvidia_installer_effective_path }}
+      {{ nvidia_installer_effective_path }} --silent --accept-license --no-questions --kernel-source-path={{ kernel_source_path }}
     become: true
     args:
       executable: /bin/bash
@@ -187,8 +192,8 @@
 
   - name: Install NVIDIA driver without kernel source path
     shell: |
-      cd /opt/nvidia
-      ./{{ nvidia_driver_installer }} --silent --accept-license --no-questions
+      chmod +x {{ nvidia_installer_effective_path }}
+      {{ nvidia_installer_effective_path }} --silent --accept-license --no-questions
     become: true
     args:
       executable: /bin/bash


### PR DESCRIPTION
…nd hardcoding (#1)

* fix: setup-ai-env path accessibility and OS-specific GRUB/toolkit commands

Agent-Logs-Url: https://github.com/DSYZayn/ocboot/sessions/083da282-6de6-429f-baf8-1753d77399c9



* fix: address code review feedback on path matching and variable naming

Agent-Logs-Url: https://github.com/DSYZayn/ocboot/sessions/083da282-6de6-429f-baf8-1753d77399c9



* fix: use USTC mirror and versioned packages for Debian nvidia-container-toolkit

Agent-Logs-Url: https://github.com/DSYZayn/ocboot/sessions/083da282-6de6-429f-baf8-1753d77399c9



---------