### PR TITLE
fix(ai-env): add Debian/Ubuntu support and fix nvidia driver installation

### DIFF
--- a/onecloud/roles/utils/ai-env/tasks/configure-containerd.yml
+++ b/onecloud/roles/utils/ai-env/tasks/configure-containerd.yml
@@ -7,13 +7,20 @@
 
 - name: Configure containerd runtime for NVIDIA
   shell: |
-    nvidia-ctk runtime configure --runtime=containerd --config /etc/yunion/containerd/config.toml
+    nvidia-ctk runtime configure --runtime=containerd --set-as-default --config /etc/yunion/containerd/config.toml
   become: true
   args:
     executable: /bin/bash
   register: runtime_config_result
 
 - debug: var=runtime_config_result.stdout_lines
+
+- name: Set default_runtime_name to nvidia in yunion-containerd config
+  replace:
+    path: /etc/yunion/containerd/config.toml
+    regexp: '(default_runtime_name\s*=\s*)"[^"]*"'
+    replace: '\1"nvidia"'
+  become: true
 
 - name: Restart yunion-containerd service
   systemd:

--- a/onecloud/roles/utils/ai-env/tasks/configure-grub-Debian.yml
+++ b/onecloud/roles/utils/ai-env/tasks/configure-grub-Debian.yml
@@ -1,0 +1,5 @@
+- name: Update GRUB configuration
+  shell: update-grub
+  become: true
+  args:
+    executable: /bin/bash

--- a/onecloud/roles/utils/ai-env/tasks/configure-grub-RedHat.yml
+++ b/onecloud/roles/utils/ai-env/tasks/configure-grub-RedHat.yml
@@ -1,0 +1,5 @@
+- name: Update GRUB configuration
+  shell: grub2-mkconfig -o "$(readlink -f /etc/grub2-efi.cfg 2>/dev/null || readlink -f /etc/grub2.cfg 2>/dev/null || echo /boot/grub2/grub.cfg)"
+  become: true
+  args:
+    executable: /bin/bash

--- a/onecloud/roles/utils/ai-env/tasks/configure-grub.yml
+++ b/onecloud/roles/utils/ai-env/tasks/configure-grub.yml
@@ -13,12 +13,8 @@
   when: grub_check.rc != 0
 
 - name: Update GRUB configuration
-  shell: grub2-mkconfig > /boot/efi/EFI/openEuler/grub.cfg
-  become: true
-  args:
-    executable: /bin/bash
+  include_tasks: "configure-grub-{{ ansible_os_family }}.yml"
   when: grub_check.rc != 0
-  register: grub_update_result
 
 - name: Reboot system after grub update
   reboot:

--- a/onecloud/roles/utils/ai-env/tasks/install-container-toolkit-Debian.yml
+++ b/onecloud/roles/utils/ai-env/tasks/install-container-toolkit-Debian.yml
@@ -1,0 +1,26 @@
+- name: Add NVIDIA Container Toolkit GPG key
+  shell: |
+    curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg --yes
+  become: true
+  args:
+    executable: /bin/bash
+
+- name: Add NVIDIA Container Toolkit repository
+  shell: |
+    curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+      sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+      tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+  become: true
+  args:
+    executable: /bin/bash
+
+- name: Update apt cache
+  apt:
+    update_cache: yes
+  become: true
+
+- name: Install NVIDIA Container Toolkit
+  apt:
+    name: nvidia-container-toolkit
+    state: present
+  become: true

--- a/onecloud/roles/utils/ai-env/tasks/install-container-toolkit-RedHat.yml
+++ b/onecloud/roles/utils/ai-env/tasks/install-container-toolkit-RedHat.yml
@@ -1,0 +1,18 @@
+- name: Add NVIDIA Container Toolkit repository
+  copy:
+    src: nvidia-container-toolkit.repo
+    dest: /etc/yum.repos.d/nvidia-container-toolkit.repo
+    mode: '0644'
+  become: true
+
+- name: Enable NVIDIA Container Toolkit experimental repository
+  shell: yum-config-manager --enable nvidia-container-toolkit-experimental
+  become: true
+  args:
+    executable: /bin/bash
+
+- name: Install NVIDIA Container Toolkit
+  package:
+    name: nvidia-container-toolkit-1.17.8-1
+    state: present
+  become: true

--- a/onecloud/roles/utils/ai-env/tasks/install-container-toolkit.yml
+++ b/onecloud/roles/utils/ai-env/tasks/install-container-toolkit.yml
@@ -8,26 +8,9 @@
   set_fact:
     container_toolkit_installed: "{{ toolkit_check.rc == 0 }}"
 
-- block:
-  - name: Add NVIDIA Container Toolkit repository
-    copy:
-      src: nvidia-container-toolkit.repo
-      dest: /etc/yum.repos.d/nvidia-container-toolkit.repo
-      mode: '0644'
-    become: true
+- name: Install NVIDIA Container Toolkit
+  include_tasks: "install-container-toolkit-{{ ansible_os_family }}.yml"
+  when: not container_toolkit_installed | default(false)
 
-  - name: Enable NVIDIA Container Toolkit experimental repository
-    shell: sudo yum-config-manager --enable nvidia-container-toolkit-experimental
-    become: true
-    args:
-      executable: /bin/bash
-
-  - name: Install NVIDIA Container Toolkit
-    package:
-      name: nvidia-container-toolkit-1.17.8-1
-      state: present
-    become: true
-
-  - debug: msg="NVIDIA Container Toolkit installed successfully"
-
+- debug: msg="NVIDIA Container Toolkit installed successfully"
   when: not container_toolkit_installed | default(false)

--- a/onecloud/roles/utils/ai-env/tasks/install-nvidia-driver-Debian.yml
+++ b/onecloud/roles/utils/ai-env/tasks/install-nvidia-driver-Debian.yml
@@ -1,0 +1,17 @@
+- name: Install kernel headers and development packages for current kernel
+  shell: |
+    KERNEL_VERSION="{{ current_kernel_version.stdout }}"
+    apt-get update && \
+    apt-get install -y linux-headers-${KERNEL_VERSION} || \
+    apt-get install -y {{ kernel_package }} {{ kernel_headers_package }} {{ kernel_devel_package }}
+  become: true
+  args:
+    executable: /bin/bash
+  register: kernel_install_result
+
+- name: Install build tools
+  package:
+    name:
+      - build-essential
+    state: present
+  become: true

--- a/onecloud/roles/utils/ai-env/tasks/install-nvidia-driver-RedHat.yml
+++ b/onecloud/roles/utils/ai-env/tasks/install-nvidia-driver-RedHat.yml
@@ -1,0 +1,19 @@
+- name: Install kernel headers and development packages for current kernel
+  shell: |
+    KERNEL_VERSION="{{ current_kernel_version.stdout }}"
+    yum install -y kernel-headers-${KERNEL_VERSION} kernel-devel-${KERNEL_VERSION} || \
+    yum install -y "kernel-headers-${KERNEL_VERSION}" "kernel-devel-${KERNEL_VERSION}" || \
+    yum install -y {{ kernel_package }} {{ kernel_headers_package }} {{ kernel_devel_package }}
+  become: true
+  args:
+    executable: /bin/bash
+  register: kernel_install_result
+
+- name: Install build tools (gcc, make, etc.)
+  package:
+    name:
+      - gcc
+      - make
+      - binutils
+    state: present
+  become: true

--- a/onecloud/roles/utils/ai-env/tasks/install-nvidia-driver.yml
+++ b/onecloud/roles/utils/ai-env/tasks/install-nvidia-driver.yml
@@ -3,49 +3,35 @@
   register: current_kernel_version
   changed_when: false
 
-- name: Install kernel headers and development packages for current kernel (RedHat)
-  shell: |
-    KERNEL_VERSION="{{ current_kernel_version.stdout }}"
-    yum install -y kernel-headers-${KERNEL_VERSION} kernel-devel-${KERNEL_VERSION} || \
-    yum install -y "kernel-headers-${KERNEL_VERSION}" "kernel-devel-${KERNEL_VERSION}" || \
-    yum install -y {{ kernel_package }} {{ kernel_headers_package }} {{ kernel_devel_package }}
+- name: Install kernel headers, development packages and build tools
+  include_tasks: "install-nvidia-driver-{{ ansible_os_family }}.yml"
+
+# 禁用 Nouveau 驱动
+- name: Blacklist nouveau driver
+  copy:
+    content: |
+      blacklist nouveau
+      options nouveau modeset=0
+    dest: /etc/modprobe.d/blacklist-nouveau.conf
+    mode: '0644'
+  become: true
+  register: nouveau_blacklisted
+
+- name: Regenerate initramfs after blacklisting nouveau (RedHat)
+  shell: dracut --force
   become: true
   args:
     executable: /bin/bash
-  register: kernel_install_result
-  when: ansible_os_family == "RedHat"
+  when: nouveau_blacklisted.changed and ansible_os_family == "RedHat"
 
-- name: Install kernel headers and development packages for current kernel (Debian)
-  shell: |
-    KERNEL_VERSION="{{ current_kernel_version.stdout }}"
-    apt-get update && \
-    apt-get install -y linux-headers-${KERNEL_VERSION} || \
-    apt-get install -y {{ kernel_package }} {{ kernel_headers_package }} {{ kernel_devel_package }}
+- name: Regenerate initramfs after blacklisting nouveau (Debian)
+  shell: update-initramfs -u
   become: true
   args:
     executable: /bin/bash
-  register: kernel_install_result
-  when: ansible_os_family == "Debian"
+  when: nouveau_blacklisted.changed and ansible_os_family == "Debian"
 
-- name: Install build tools (gcc, make, etc.) for RedHat
-  package:
-    name:
-      - gcc
-      - make
-      - binutils
-    state: present
-  become: true
-  when: ansible_os_family == "RedHat"
-
-- name: Install build tools (gcc, make, etc.) for Debian
-  package:
-    name:
-      - build-essential
-    state: present
-  become: true
-  when: ansible_os_family == "Debian"
-
-# 新增：清理vfio相关配置和grub参数，重建grub并重启
+# 清理vfio相关配置和grub参数，重建grub并重启
 - name: 删除 /etc/modules-load.d/vfio.conf
   file:
     path: /etc/modules-load.d/vfio.conf
@@ -87,10 +73,7 @@
   register: grub_iommu_removed
 
 - name: 重新生成 grub 配置
-  shell: grub2-mkconfig > /boot/efi/EFI/openEuler/grub.cfg
-  become: true
-  args:
-    executable: /bin/bash
+  include_tasks: "configure-grub-{{ ansible_os_family }}.yml"
   when: grub_vfio_removed.changed or grub_iommu_removed.changed
 
 - name: 重启系统
@@ -102,7 +85,7 @@
     post_reboot_delay: 30
     test_command: whoami
   become: true
-  when: kernel_install_result.changed or grub_vfio_removed.changed or grub_iommu_removed.changed 
+  when: kernel_install_result.changed or nouveau_blacklisted.changed or grub_vfio_removed.changed or grub_iommu_removed.changed
 
 - name: Check if NVIDIA driver is already installed
   shell: nvidia-smi

--- a/onecloud/roles/utils/ai-env/tasks/post-tasks.yml
+++ b/onecloud/roles/utils/ai-env/tasks/post-tasks.yml
@@ -27,3 +27,9 @@
   debug:
     msg: "Container Toolkit status: {{ toolkit_verification.stdout_lines }}"
   when: toolkit_verification.rc == 0
+
+- name: Restart host service by killing /opt/yunion/bin/host process
+  shell: pgrep -xf '/opt/yunion/bin/host --common-config-file.*' | xargs -r kill || true
+  become: true
+  args:
+    executable: /bin/bash


### PR DESCRIPTION
- Split OS-specific tasks (grub, container-toolkit, nvidia-driver) into separate RedHat and Debian files, included via ansible_os_family
- Add Debian support for container-toolkit using apt and GPG keyring
- Use update-grub for Debian instead of hardcoded OpenEuler grub path
- Blacklist nouveau driver and regenerate initramfs before nvidia install
- Set nvidia as default containerd runtime in yunion-containerd config
- Restart host service after setup completion