### PR TITLE
chore(run,scripts): add deploy guard and k3s cert renewal scripts

### DIFF
--- a/run.py
+++ b/run.py
@@ -522,8 +522,35 @@ def generate_config(
 parser = None
 
 
+def check_cluster_deployed(ipaddr):
+    """检查目标节点是否已经部署了 OneCloud 集群。
+    通过 SSH 到目标节点执行 kubectl 命令来检测。
+    """
+    username = get_username()
+    # 尝试通过 SSH 在目标节点上执行 kubectl 命令检查 onecloud 集群是否存在
+    # 先尝试 k3s kubectl，再尝试 kubectl
+    check_cmd = (
+        "k3s kubectl -n onecloud get onecloudclusters default -o name 2>/dev/null"
+        " || kubectl -n onecloud get onecloudclusters default -o name 2>/dev/null"
+    )
+    ssh_cmd = (
+        f"ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no"
+        f" -o PasswordAuthentication=no -o LogLevel=error"
+        f" {username}@{ipaddr} '{check_cmd}'"
+    )
+    try:
+        ret = subprocess.run(ssh_cmd, shell=True, capture_output=True, timeout=15)
+        if ret.returncode == 0 and b'onecloudcluster' in ret.stdout.lower():
+            return True
+    except (subprocess.TimeoutExpired, Exception):
+        pass
+    return False
+
+
 def inject_common_options(parser):
     """添加 run.py 中所有命令共用的参数"""
+    parser.add_argument('--force', action='store_true', default=False,
+                       help="Force install even if a cluster is already deployed on the target node")
     parser.add_argument('--ip-dual-conf', type=str, dest='ip_dual_conf',
                        help="Input the second IP address for dual-stack configuration (IPv6 if IP_CONF is IPv4, or IPv4 if IP_CONF is IPv6)")
     parser.add_argument('--enable-ipip', action='store_true', dest='enable_ipip',
@@ -681,7 +708,13 @@ def main():
         exit()
     
     check_env(ip_conf, pip_mirror=args.pip_mirror)
-    
+
+    # 检查目标节点是否已经部署了集群
+    if not args.force:
+        if check_cluster_deployed(ip_conf):
+            pr_red(f"Error: A OneCloud cluster is already deployed on {ip_conf}.")
+            sys.exit(1)
+
     # 如果是 ai 模式，设置 enable_ai_env，并根据是否提供参数决定是否传递 NVIDIA 变量
     extra_vars = None
     if is_ai_mode:

--- a/scripts/renew-k3s-agent-certs.sh
+++ b/scripts/renew-k3s-agent-certs.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -e
+
+# Renew k3s agent certificates using `k3s certificate rotate` and restart k3s-agent.
+#
+# Usage:
+#   ./renew-k3s-agent-certs.sh <agent_host> [ssh_user] [ssh_port]
+#
+# Examples:
+#   ./renew-k3s-agent-certs.sh 10.0.0.10
+#   ./renew-k3s-agent-certs.sh 10.0.0.10 root 22
+#   ./renew-k3s-agent-certs.sh "10.0.0.10 10.0.0.11 10.0.0.12"
+
+AGENT_HOSTS="${1:?Usage: $0 <agent_host(s)> [ssh_user] [ssh_port]}"
+SSH_USER="${2:-root}"
+SSH_PORT="${3:-22}"
+
+SSH_OPTS="-o StrictHostKeyChecking=no -o ConnectTimeout=10 -p ${SSH_PORT}"
+
+renew_agent_certs() {
+    local host="$1"
+    echo "=========================================="
+    echo "Processing k3s-agent on: ${host}"
+    echo "=========================================="
+
+    ssh ${SSH_OPTS} "${SSH_USER}@${host}" bash <<'REMOTE_SCRIPT'
+set -e
+
+echo "[1/3] Checking k3s-agent status..."
+if ! systemctl is-enabled k3s-agent &>/dev/null; then
+    echo "ERROR: k3s-agent service not found on this host, skipping."
+    exit 1
+fi
+
+echo "[2/4] Stopping k3s-agent..."
+systemctl stop k3s-agent
+
+echo "[3/4] Rotating k3s agent certificates..."
+k3s certificate rotate
+
+echo "[4/4] Starting k3s-agent..."
+systemctl start k3s-agent
+
+sleep 5
+if systemctl is-active k3s-agent &>/dev/null; then
+    echo "SUCCESS: k3s-agent is running on $(hostname)"
+else
+    echo "ERROR: k3s-agent failed to start. Check: journalctl -u k3s-agent -n 50"
+    exit 1
+fi
+REMOTE_SCRIPT
+
+    echo ""
+}
+
+# Process each host
+for host in ${AGENT_HOSTS}; do
+    renew_agent_certs "${host}"
+done
+
+echo "All done."

--- a/scripts/renew-k3s-server-certs.sh
+++ b/scripts/renew-k3s-server-certs.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -e
+
+# Renew k3s server (control plane) certificates using `k3s certificate rotate`.
+# Ensures CATTLE_NEW_SIGNED_CERT_EXPIRATION_DAYS is set so new certs are valid for 10 years.
+#
+# Usage:
+#   ./renew-k3s-server-certs.sh <server_host> [ssh_user] [ssh_port]
+#
+# Examples:
+#   ./renew-k3s-server-certs.sh 10.0.0.1
+#   ./renew-k3s-server-certs.sh 10.0.0.1 root 22
+#   ./renew-k3s-server-certs.sh "10.0.0.1 10.0.0.2 10.0.0.3"
+
+SERVER_HOSTS="${1:?Usage: $0 <server_host(s)> [ssh_user] [ssh_port]}"
+SSH_USER="${2:-root}"
+SSH_PORT="${3:-22}"
+
+SSH_OPTS="-o StrictHostKeyChecking=no -o ConnectTimeout=10 -p ${SSH_PORT}"
+
+renew_server_certs() {
+    local host="$1"
+    echo "=========================================="
+    echo "Processing k3s server on: ${host}"
+    echo "=========================================="
+
+    ssh ${SSH_OPTS} "${SSH_USER}@${host}" bash <<'REMOTE_SCRIPT'
+set -e
+
+K3S_SERVICE_ENV="/etc/systemd/system/k3s.service.env"
+
+echo "[1/5] Checking k3s service status..."
+if ! systemctl is-enabled k3s &>/dev/null; then
+    echo "ERROR: k3s service not found on this host, skipping."
+    exit 1
+fi
+
+echo "[2/5] Ensuring CATTLE_NEW_SIGNED_CERT_EXPIRATION_DAYS=3650 in ${K3S_SERVICE_ENV}..."
+if [ -f "${K3S_SERVICE_ENV}" ]; then
+    if grep -q "^CATTLE_NEW_SIGNED_CERT_EXPIRATION_DAYS=" "${K3S_SERVICE_ENV}"; then
+        sed -i 's/^CATTLE_NEW_SIGNED_CERT_EXPIRATION_DAYS=.*/CATTLE_NEW_SIGNED_CERT_EXPIRATION_DAYS=3650/' "${K3S_SERVICE_ENV}"
+    else
+        echo "CATTLE_NEW_SIGNED_CERT_EXPIRATION_DAYS=3650" >> "${K3S_SERVICE_ENV}"
+    fi
+else
+    echo "CATTLE_NEW_SIGNED_CERT_EXPIRATION_DAYS=3650" > "${K3S_SERVICE_ENV}"
+fi
+echo "  $(grep CATTLE_NEW_SIGNED_CERT_EXPIRATION_DAYS ${K3S_SERVICE_ENV})"
+
+echo "[3/5] Stopping k3s..."
+systemctl stop k3s
+
+echo "[4/5] Rotating k3s server certificates..."
+k3s certificate rotate
+
+echo "[5/5] Starting k3s..."
+systemctl daemon-reload
+systemctl start k3s
+
+sleep 5
+if systemctl is-active k3s &>/dev/null; then
+    echo "SUCCESS: k3s server is running on $(hostname)"
+else
+    echo "ERROR: k3s failed to start. Check: journalctl -u k3s -n 50"
+    exit 1
+fi
+REMOTE_SCRIPT
+
+    echo ""
+}
+
+# Process each host
+for host in ${SERVER_HOSTS}; do
+    renew_server_certs "${host}"
+done
+
+echo "All done."


### PR DESCRIPTION
Prevent accidental re-deployment by checking if a OneCloud cluster already exists on the target node (bypassable with --force). Add scripts to rotate k3s server and agent certificates via SSH.