### PR TITLE
Automated cherry pick of #1645: fix(ubuntu): preserve DNS from resolvectl before resolved restart

### DIFF
--- a/onecloud/roles/common/tasks/os/ubuntu_20.yml
+++ b/onecloud/roles/common/tasks/os/ubuntu_20.yml
@@ -1,26 +1,6 @@
 ---
-- block:
-  - name: Write /etc/systemd/resolved.conf
-    become: true
-    template:
-      src: etc_systemd_resolved.conf.j2
-      dest: /etc/systemd/resolved.conf
-      owner: root
-      group: root
-      mode: 0644
-
-  - name: Restart systemd-resolved
-    become: true
-    service:
-      name: systemd-resolved
-      state: restarted
-
-  - name: Link /etc/resolv.conf to /run/systemd/resolve/resolve.conf
-    become: true
-    shell: |
-      ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
-    args:
-      executable: /bin/bash
+- name: Configure systemd-resolved for legacy DNS
+  include_tasks: utils/configure_systemd_resolved.yml
 
 - name: Include Debian Family Common Tasks
   include_tasks: debian_family.yml

--- a/onecloud/roles/common/tasks/os/ubuntu_22.yml
+++ b/onecloud/roles/common/tasks/os/ubuntu_22.yml
@@ -1,26 +1,6 @@
 ---
-- block:
-  - name: Write /etc/systemd/resolved.conf
-    become: true
-    template:
-      src: etc_systemd_resolved.conf.j2
-      dest: /etc/systemd/resolved.conf
-      owner: root
-      group: root
-      mode: 0644
-
-  - name: Restart systemd-resolved
-    become: true
-    service:
-      name: systemd-resolved
-      state: restarted
-
-  - name: Link /etc/resolv.conf to /run/systemd/resolve/resolve.conf
-    become: true
-    shell: |
-      ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
-    args:
-      executable: /bin/bash
+- name: Configure systemd-resolved for legacy DNS
+  include_tasks: utils/configure_systemd_resolved.yml
 
 - name: Include Debian Family Common Tasks
   include_tasks: debian_family.yml

--- a/onecloud/roles/common/tasks/os/ubuntu_24.yml
+++ b/onecloud/roles/common/tasks/os/ubuntu_24.yml
@@ -1,26 +1,6 @@
 ---
-- block:
-  - name: Write /etc/systemd/resolved.conf
-    become: true
-    template:
-      src: etc_systemd_resolved.conf.j2
-      dest: /etc/systemd/resolved.conf
-      owner: root
-      group: root
-      mode: 0644
-
-  - name: Restart systemd-resolved
-    become: true
-    service:
-      name: systemd-resolved
-      state: restarted
-
-  - name: Link /etc/resolv.conf to /run/systemd/resolve/resolve.conf
-    become: true
-    shell: |
-      ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
-    args:
-      executable: /bin/bash
+- name: Configure systemd-resolved for legacy DNS
+  include_tasks: utils/configure_systemd_resolved.yml
 
 - name: Include Debian Family Common Tasks
   include_tasks: debian_family.yml

--- a/onecloud/roles/common/tasks/os/ubuntu_25.yml
+++ b/onecloud/roles/common/tasks/os/ubuntu_25.yml
@@ -1,26 +1,6 @@
 ---
-- block:
-  - name: Write /etc/systemd/resolved.conf
-    become: true
-    template:
-      src: etc_systemd_resolved.conf.j2
-      dest: /etc/systemd/resolved.conf
-      owner: root
-      group: root
-      mode: 0644
-
-  - name: Restart systemd-resolved
-    become: true
-    service:
-      name: systemd-resolved
-      state: restarted
-
-  - name: Link /etc/resolv.conf to /run/systemd/resolve/resolve.conf
-    become: true
-    shell: |
-      ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
-    args:
-      executable: /bin/bash
+- name: Configure systemd-resolved for legacy DNS
+  include_tasks: utils/configure_systemd_resolved.yml
 
 - name: Include Debian Family Common Tasks
   include_tasks: debian_family.yml

--- a/onecloud/roles/common/tasks/utils/configure_systemd_resolved.yml
+++ b/onecloud/roles/common/tasks/utils/configure_systemd_resolved.yml
@@ -1,0 +1,52 @@
+---
+- name: Collect current DNS servers from resolvectl
+  become: true
+  shell: |
+    resolvectl dns 2>/dev/null \
+      | awk '
+        /^Global:/ {
+          sub(/^Global:[[:space:]]*/, "")
+          if ($0 != "") print
+          next
+        }
+        /^Link / {
+          sub(/^Link [0-9]+ \([^)]+\):[[:space:]]*/, "")
+          if ($0 != "") print
+        }' \
+      | tr ' ' '\n' \
+      | grep -E '^([0-9]{1,3}\.){3}[0-9]{1,3}$|^([0-9a-fA-F]{0,4}:){1,7}[0-9a-fA-F]{0,4}$' \
+      | grep -v '^127\.0\.0\.53$' \
+      | sort -u \
+      | paste -sd' ' -
+  args:
+    executable: /bin/bash
+  register: resolvectl_dns
+  changed_when: false
+  failed_when: false
+
+- name: Set systemd resolved DNS servers fact
+  set_fact:
+    systemd_resolved_dns_servers: "{{ resolvectl_dns.stdout | trim }}"
+  when: resolvectl_dns.stdout | trim | length > 0
+
+- name: Write /etc/systemd/resolved.conf
+  become: true
+  template:
+    src: etc_systemd_resolved.conf.j2
+    dest: /etc/systemd/resolved.conf
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Restart systemd-resolved
+  become: true
+  service:
+    name: systemd-resolved
+    state: restarted
+
+- name: Link /etc/resolv.conf to /run/systemd/resolve/resolv.conf
+  become: true
+  shell: |
+    ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
+  args:
+    executable: /bin/bash

--- a/onecloud/roles/common/templates/etc_systemd_resolved.conf.j2
+++ b/onecloud/roles/common/templates/etc_systemd_resolved.conf.j2
@@ -19,7 +19,11 @@
 # Cloudflare: 1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com 2606:4700:4700::1111#cloudflare-dns.com 2606:4700:4700::1001#cloudflare-dns.com
 # Google:     8.8.8.8#dns.google 8.8.4.4#dns.google 2001:4860:4860::8888#dns.google 2001:4860:4860::8844#dns.google
 # Quad9:      9.9.9.9#dns.quad9.net 149.112.112.112#dns.quad9.net 2620:fe::fe#dns.quad9.net 2620:fe::9#dns.quad9.net
+{% if systemd_resolved_dns_servers | default('') | length > 0 %}
+DNS={{ systemd_resolved_dns_servers }}
+{% else %}
 #DNS=
+{% endif %}
 #FallbackDNS=
 #Domains=
 #DNSSEC=no

--- a/onecloud/roles/primary-master-node/setup_cloud/tasks/main.yml
+++ b/onecloud/roles/primary-master-node/setup_cloud/tasks/main.yml
@@ -251,6 +251,8 @@
   ignore_errors: yes
   retries: 3
   delay: 10
+  args:
+    executable: /bin/bash
 
 - name: "Create onecloud web login user {{ onecloud_user }}"
   shell: |
@@ -406,7 +408,7 @@
 - name: add default host-local network
   shell: |
     source ~/.onecloud_rcadmin
-    if [ $(/opt/yunion/bin/climc network-list --scope system | grep -w vhl0 | wc -l) -eq 0 ]; then
+    if [ $(/opt/yunion/bin/climc network-list --scope system | grep -w vh0 | wc -l) -eq 0 ]; then
       /opt/yunion/bin/climc network-create3 --server-type hostlocal __host_local__ vh0 --start-ip 10.255.192.2 --end-ip 10.255.255.254 --net-mask 18 --gateway 10.255.192.1 --desc 'Default hostlocal virtual network'
     fi
   become: yes


### PR DESCRIPTION
Cherry pick of #1645 on release/4.0.

#1645: fix(ubuntu): preserve DNS from resolvectl before resolved restart