### PR TITLE
feat(clickhouse): support standalone host and custom data path

### DIFF
--- a/lib/ocboot.py
+++ b/lib/ocboot.py
@@ -403,6 +403,7 @@ class ClickhouseConfig(object):
         self.node = Node(config).with_bastion(bastion_host)
         self.ch_password = config.ensure_get('ch_password')
         self.ch_port = config.get('ch_port', 9000)
+        self.ch_data_path = config.get('ch_data_path', '/opt/clickhouse')
 
     @classmethod
     def get_group(cls):
@@ -415,6 +416,7 @@ class ClickhouseConfig(object):
         vars = {
             "ch_password": self.ch_password,
             "ch_port": self.ch_port,
+            "ch_data_path": self.ch_data_path,
         }
         return vars
 

--- a/lib/service.py
+++ b/lib/service.py
@@ -3,7 +3,7 @@
 
 from __future__ import unicode_literals
 
-from .ocboot import KEY_DISK_PATHS, KEY_ENABLE_CONTAINERD, KEY_HOST_NETWORKS, KEY_IMAGE_REPOSITORY, KEY_K8S_CONTROLPLANE_HOST, ClickhouseConfig, NodeConfig, Config, get_ansible_global_vars_by_cluster, KEY_PRIMARY_MASTER_NODE_IP
+from .ocboot import KEY_DISK_PATHS, KEY_ENABLE_CONTAINERD, KEY_HOST_NETWORKS, KEY_IMAGE_REPOSITORY, KEY_K8S_CONTROLPLANE_HOST, GROUP_PRIMARY_MASTER_NODE, ClickhouseConfig, Node, NodeConfig, Config, get_ansible_global_vars_by_cluster, KEY_PRIMARY_MASTER_NODE_IP
 from .cmd import run_ansible_playbook
 from .ansible import get_inventory_config
 from .parser import help_d, inject_add_hostagent_options, inject_primary_node_options, inject_ssh_options
@@ -375,25 +375,51 @@ class AutoBackupService(Service):
         return config.run(self.action)
 
 
+class PrimaryMasterNodeConfig(object):
+
+    def __init__(self, config, bastion_host=None):
+        self.node = Node(config).with_bastion(bastion_host)
+
+    @classmethod
+    def get_group(cls):
+        return GROUP_PRIMARY_MASTER_NODE
+
+    def get_nodes(self):
+        return [self.node]
+
+    def ansible_vars(self):
+        return {}
+
+
 class ClickhouseServiceConfig(object):
 
-    def __init__(self, cluster, primary_host,
+    def __init__(self, cluster, primary_host, clickhouse_host,
                  ch_pwd, ch_port, offline_data_path,
+                 ch_data_path='/opt/clickhouse',
                  ssh_user='root', ssh_port=22):
-        cfg = {
-            'host': primary_host,
+        ch_cfg = {
+            'host': clickhouse_host,
             'user': ssh_user,
             'port': ssh_port,
             'ch_password': ch_pwd,
             'ch_port': ch_port,
+            'ch_data_path': ch_data_path,
+        }
+        primary_cfg = {
+            'host': primary_host,
+            'user': ssh_user,
+            'port': ssh_port,
         }
         self.cluster = cluster
         self.primary_host = primary_host
-        self.ch_config = ClickhouseConfig(Config(cfg))
+        self.clickhouse_host = clickhouse_host
+        self.ch_config = ClickhouseConfig(Config(ch_cfg))
+        self.primary_config = PrimaryMasterNodeConfig(Config(primary_cfg))
         self.offline_data_path = offline_data_path
 
     def run(self):
-        inventory_content = ansible.get_inventory_config(self.ch_config)
+        inventory_content = ansible.get_inventory_config(
+            self.ch_config, self.primary_config)
         yaml_content = utils.to_yaml(inventory_content)
         filepath = './cluster_clickhouse_inventory.yml'
         with open(filepath, 'w') as f:
@@ -409,6 +435,7 @@ class ClickhouseServiceConfig(object):
         vars = self.ch_config.ansible_vars()
         vars['offline_data_path'] = self.offline_data_path
         vars[KEY_K8S_CONTROLPLANE_HOST] = self.primary_host
+        vars['ch_host'] = self.ch_config.node.node_ip
         global_vars = get_ansible_global_vars_by_cluster(self.cluster)
         vars.update(global_vars)
         return vars
@@ -424,24 +451,42 @@ class ClickhouseService(BaseService):
         inject_ssh_options(parser)
         parser.add_argument("offline_data_path",
                             metavar='OFFLINE_DATA_PATH',
-                            help="offline ISO mount point, e.g., /mnt")
+                            help="offline ISO mount point for RPM repo, e.g., /mnt")
         parser.add_argument("--ch-password", dest="ch_password",
                             help=help_d("clickhouse password"))
         parser.add_argument("--ch-port", dest="ch_port",
                             default=9000, type=int,
                             help=help_d("clickhouse port"))
+        parser.add_argument("--ch-data-path", dest="ch_data_path",
+                            default='/opt/clickhouse',
+                            help=help_d("clickhouse data directory"))
+        parser.add_argument("--clickhouse-host", dest="clickhouse_host",
+                            default=None,
+                            help=help_d("clickhouse target host, "
+                                        "defaults to primary master host"))
 
     def do_action(self, args):
-        # config = 
         if args.ch_password is None:
             args.ch_password = utils.generage_random_string(12)
             print(f'generated clickhouse password: {args.ch_password}')
+        clickhouse_host = args.clickhouse_host or args.primary_master_host
         cluster = construct_cluster(
             args.primary_master_host,
             args.ssh_user,
             args.ssh_private_file,
             args.ssh_port)
         print(f'found cluster {cluster.get_current_version()}')
-        config = ClickhouseServiceConfig(cluster,
-            args.primary_master_host, args.ch_password, args.ch_port, args.offline_data_path, args.ssh_user, args.ssh_port)
+        if clickhouse_host != args.primary_master_host:
+            print(f'deploy clickhouse on {clickhouse_host}, '
+                  f'patch cluster via primary master {args.primary_master_host}')
+        config = ClickhouseServiceConfig(
+            cluster,
+            args.primary_master_host,
+            clickhouse_host,
+            args.ch_password,
+            args.ch_port,
+            args.offline_data_path,
+            args.ch_data_path,
+            args.ssh_user,
+            args.ssh_port)
         return config.run()

--- a/onecloud/clickhouse-services.yml
+++ b/onecloud/clickhouse-services.yml
@@ -2,4 +2,8 @@
   roles:
     - { role: utils/detect-os }
     - { role: clickhouse/install }
+
+- hosts: primary_master_node
+  roles:
+    - { role: utils/detect-os }
     - { role: clickhouse/deploy }

--- a/onecloud/roles/clickhouse/deploy/templates/clickhouse.spec.j2
+++ b/onecloud/roles/clickhouse/deploy/templates/clickhouse.spec.j2
@@ -1,6 +1,6 @@
 spec:
   clickhouse:
     username: "default"
-    host: {{ node_ip }}
+    host: {{ ch_host | default(node_ip) }}
     password: {{ ch_password }}
     port: {{ ch_port }}

--- a/onecloud/roles/clickhouse/install/tasks/main.yml
+++ b/onecloud/roles/clickhouse/install/tasks/main.yml
@@ -37,7 +37,7 @@
 
   - name: Mkdir for data path
     ansible.builtin.file:
-      path: /opt/clickhouse
+      path: "{{ ch_data_path | default('/opt/clickhouse') }}"
       state: directory
       owner: clickhouse
       group: clickhouse
@@ -45,8 +45,8 @@
   - name: Change data path
     replace:
       path: /etc/clickhouse-server/config.xml
-      regexp: 'path>/var/lib/clickhouse/'
-      replace: 'path>/opt/clickhouse/'
+      regexp: 'path>(?:/var/lib/clickhouse|/opt/clickhouse|{{ ch_data_path | default("/opt/clickhouse") | regex_escape }})/'
+      replace: 'path>{{ ch_data_path | default("/opt/clickhouse") }}/'
       backup: yes
 
   - name: Change default port

--- a/run.py
+++ b/run.py
@@ -268,6 +268,8 @@ conf = """
 #   user: ocboot_user
 #   # Password of clickhouse
 #   ch_password: your-clickhouse-password
+#   # Data directory of clickhouse (default: /opt/clickhouse)
+#   ch_data_path: /data/clickhouse
 # mariadb_node indicates the node where the mariadb service needs to be deployed
 mariadb_node:
   # IP of the machine to be deployed


### PR DESCRIPTION
Allow ocboot clickhouse to install on a separate VM while patching the cluster from primary master, and add --ch-data-path to configure ClickHouse storage directory instead of hardcoded /opt/clickhouse.