### PR TITLE
feat: add network CIDR validation and conflict checks

### DIFF
--- a/lib/install.py
+++ b/lib/install.py
@@ -87,6 +87,7 @@ def try_reboot_primary(ip):
 
 def start(config_file, extra_vars=None):
     config = ocboot.load_config(config_file)
+    config.check_network_cidr_conflicts()
 
     k3s.init_airgap_assets(k3s.GET_AIRGAP_DIR(), k3s.VERSION_V1_28_5_K3S_1)
 

--- a/lib/ocboot.py
+++ b/lib/ocboot.py
@@ -234,6 +234,69 @@ class OcbootConfig(object):
     def is_using_ee(self):
         return self.primary_master_config.use_ee
 
+    def _collect_k8s_node_ips(self):
+        ips = []
+        seen = set()
+
+        def add(label, ip_str):
+            if not ip_str or ip_str == '127.0.0.1':
+                return
+            if utils.parse_ip(ip_str) is None:
+                return
+            if ip_str in seen:
+                return
+            seen.add(ip_str)
+            ips.append((label, ip_str))
+
+        def collect_from_config(conf, group_name):
+            if not conf:
+                return
+            for node in conf.get_nodes():
+                add(group_name, node.host)
+                if node.node_ip != node.host:
+                    add(group_name, node.node_ip)
+
+        collect_from_config(self.primary_master_config, GROUP_PRIMARY_MASTER_NODE)
+        if self.primary_master_config:
+            pc = self.primary_master_config
+            if pc.ip_type == consts.IP_TYPE_DUAL_STACK:
+                if getattr(pc, 'node_ip_v4', None):
+                    add(GROUP_PRIMARY_MASTER_NODE, pc.node_ip_v4)
+                if getattr(pc, 'node_ip_v6', None):
+                    add(GROUP_PRIMARY_MASTER_NODE, pc.node_ip_v6)
+            add('controlplane_host', pc.controlplane_host)
+            if pc.high_availability_vip:
+                add('high_availability_vip', pc.high_availability_vip)
+
+        collect_from_config(self.master_config, GROUP_MASTER_NODES)
+        collect_from_config(self.worker_config, GROUP_WORKER_NODES)
+        return ips
+
+    def _get_network_cidrs(self, pc):
+        if pc.ip_type == consts.IP_TYPE_DUAL_STACK:
+            return [
+                ('pod_network_cidr', pc.pod_network_cidr),
+                ('service_cidr', pc.service_cidr),
+                ('pod_network_cidr_v4', pc.pod_network_cidr_v4),
+                ('service_cidr_v4', pc.service_cidr_v4),
+            ]
+        return [
+            ('pod_network_cidr', pc.pod_network_cidr),
+            ('service_cidr', pc.service_cidr),
+        ]
+
+    def check_network_cidr_conflicts(self):
+        if os.getenv("IGNORE_ALL_CHECKS") == "true":
+            return
+        pc = self.primary_master_config
+        if not pc:
+            return
+        ips = self._collect_k8s_node_ips()
+        cidrs = self._get_network_cidrs(pc)
+        errors = utils.check_ips_against_cidrs(ips, cidrs)
+        if errors:
+            raise Exception(Red("\n".join(errors)))
+
 
 class ConfigNotFoundException(Exception):
 

--- a/lib/service.py
+++ b/lib/service.py
@@ -3,6 +3,8 @@
 
 from __future__ import unicode_literals
 
+import os
+
 from .ocboot import KEY_DISK_PATHS, KEY_ENABLE_CONTAINERD, KEY_HOST_NETWORKS, KEY_IMAGE_REPOSITORY, KEY_K8S_CONTROLPLANE_HOST, ClickhouseConfig, NodeConfig, Config, get_ansible_global_vars_by_cluster, KEY_PRIMARY_MASTER_NODE_IP
 from .cmd import run_ansible_playbook
 from .ansible import get_inventory_config
@@ -231,6 +233,12 @@ class AddNodesConfig(object):
             if target_hostname in target_hostnames:
                 raise Exception(Red(f"Node {target_hostname}[{target_node}] already exists in cluster (By Hostname Check). "))
 
+        self._check_target_nodes_cidr_conflicts(
+            cluster, target_nodes,
+            kwargs.get('ip_dual_conf'),
+            kwargs.get('node_ip_v4'),
+            kwargs.get('node_ip_v6'))
+
         self.current_version = cluster.get_current_version()
         controlplane_host = cluster.get_cluster_controlplane_host()
         primary_master_node_ip = cluster.get_primary_master_node_ip()
@@ -275,6 +283,36 @@ class AddNodesConfig(object):
         self.cuda_installer_path = kwargs.get('cuda_installer_path')
 
         utils.pr_green(f"Get current cluster: {controlplane_host}, primary_master_node_ip: {primary_master_node_ip}, version: {self.current_version}, is_using_k3s: {self.is_using_k3s}")
+
+    @staticmethod
+    def _check_target_nodes_cidr_conflicts(cluster, target_nodes, ip_dual_conf=None,
+                                         node_ip_v4=None, node_ip_v6=None):
+        if os.getenv("IGNORE_ALL_CHECKS") == "true":
+            return
+        if not cluster.is_using_k3s():
+            return
+        try:
+            config_yaml = cluster.ssh_client.exec_command(
+                'cat /etc/rancher/k3s/config.yaml', use_sudo=True)
+        except Exception as e:
+            raise Exception(Red(
+                "Failed to read k3s config from primary master: %s" % e))
+
+        cidrs = utils.parse_k3s_network_cidrs(config_yaml)
+        if not cidrs:
+            return
+
+        ips = []
+        seen = set()
+        for ip_str in list(target_nodes) + [ip_dual_conf, node_ip_v4, node_ip_v6]:
+            if not ip_str or ip_str in seen:
+                continue
+            seen.add(ip_str)
+            ips.append(('worker_node', ip_str))
+
+        errors = utils.check_ips_against_cidrs(ips, cidrs)
+        if errors:
+            raise Exception(Red("\n".join(errors)))
 
     def run(self):
         inventory_content = ansible.get_inventory_config(self.worker_config)

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 from datetime import datetime, tzinfo, timedelta
+import ipaddress
 import os
 import re
 import socket
@@ -128,3 +129,110 @@ def is_ipv6(addr):
         return True
     except (OSError, AttributeError, socket.error):
         return False
+
+
+def parse_ip(addr):
+    if not addr or addr == '127.0.0.1':
+        return None
+    try:
+        return ipaddress.ip_address(addr)
+    except ValueError:
+        return None
+
+
+def ip_in_cidr(ip_str, cidr_str):
+    ip = parse_ip(ip_str)
+    if ip is None:
+        return False
+    try:
+        network = ipaddress.ip_network(cidr_str, strict=False)
+    except ValueError as e:
+        raise Exception("Invalid CIDR format: %s" % cidr_str) from e
+    if ip.version != network.version:
+        return False
+    return ip in network
+
+
+def check_ips_against_cidrs(ips, cidrs):
+    errors = []
+    for label, ip_str in ips:
+        ip = parse_ip(ip_str)
+        if ip is None:
+            continue
+        for cidr_name, cidr_str in cidrs:
+            try:
+                network = ipaddress.ip_network(cidr_str, strict=False)
+            except ValueError:
+                raise Exception("Invalid CIDR format: %s" % cidr_str)
+            if ip.version != network.version:
+                continue
+            if ip in network:
+                errors.append(
+                    "Node IP %s (%s) conflicts with %s %s" % (
+                        ip_str, label, cidr_name, cidr_str))
+    return errors
+
+
+def parse_k3s_network_cidrs(config_yaml):
+    import yaml
+    try:
+        data = yaml.safe_load(config_yaml) or {}
+    except yaml.YAMLError as e:
+        raise Exception("Failed to parse k3s config.yaml: %s" % e) from e
+
+    cidrs = []
+    cluster_cidr = data.get('cluster-cidr')
+    service_cidr = data.get('service-cidr')
+
+    if cluster_cidr:
+        for part in str(cluster_cidr).split(','):
+            part = part.strip()
+            if part:
+                cidrs.append(('pod_network_cidr', part))
+
+    if service_cidr:
+        for part in str(service_cidr).split(','):
+            part = part.strip()
+            if part:
+                cidrs.append(('service_cidr', part))
+
+    return cidrs
+
+
+def validate_cidr(cidr_str, name, version=None):
+    try:
+        network = ipaddress.ip_network(cidr_str, strict=False)
+    except ValueError as e:
+        raise Exception("Invalid %s CIDR format: %s" % (name, cidr_str)) from e
+    if version is not None and network.version != version:
+        raise Exception("%s must be IPv%d CIDR, got: %s" % (name, version, cidr_str))
+    return str(network)
+
+
+def apply_cidr_to_config_dict(config_dict, ip_type=None, pod_network_cidr=None,
+                              service_cidr=None, pod_network_cidr_v4=None,
+                              service_cidr_v4=None):
+    changed = False
+
+    if pod_network_cidr is not None:
+        config_dict['pod_network_cidr'] = pod_network_cidr
+        changed = True
+    if service_cidr is not None:
+        config_dict['service_cidr'] = service_cidr
+        changed = True
+    if pod_network_cidr_v4 is not None:
+        config_dict['pod_network_cidr_v4'] = pod_network_cidr_v4
+        changed = True
+    if service_cidr_v4 is not None:
+        config_dict['service_cidr_v4'] = service_cidr_v4
+        changed = True
+
+    if ip_type == 'ipv4':
+        if pod_network_cidr_v4 is not None:
+            config_dict['pod_network_cidr'] = pod_network_cidr_v4
+            changed = True
+        if service_cidr_v4 is not None:
+            config_dict['service_cidr'] = service_cidr_v4
+            changed = True
+
+    return changed

--- a/run.py
+++ b/run.py
@@ -18,6 +18,7 @@ from lib.utils import init_local_user_path
 from lib.utils import pr_red, pr_green
 from lib.utils import regex_search
 from lib.utils import is_valid_dns
+from lib.utils import validate_cidr, apply_cidr_to_config_dict
 from lib import ocboot
 from lib import consts
 
@@ -378,13 +379,106 @@ def update_config(yaml_conf, produc_stack, runtime):
     return yaml_conf
 
 
+def has_cidr_args(pod_network_cidr=None, service_cidr=None,
+                  pod_network_cidr_v4=None, service_cidr_v4=None):
+    return any(v is not None for v in (
+        pod_network_cidr, service_cidr, pod_network_cidr_v4, service_cidr_v4))
+
+
+def validate_cli_cidrs(args, ip_type):
+    if args.pod_network_cidr_v4 is not None:
+        validate_cidr(args.pod_network_cidr_v4, 'pod_network_cidr_v4', version=4)
+    if args.service_cidr_v4 is not None:
+        validate_cidr(args.service_cidr_v4, 'service_cidr_v4', version=4)
+    if args.pod_network_cidr is not None:
+        if ip_type == consts.IP_TYPE_IPV4:
+            validate_cidr(args.pod_network_cidr, 'pod_network_cidr', version=4)
+        elif ip_type in (consts.IP_TYPE_IPV6, consts.IP_TYPE_DUAL_STACK):
+            validate_cidr(args.pod_network_cidr, 'pod_network_cidr', version=6)
+        else:
+            validate_cidr(args.pod_network_cidr, 'pod_network_cidr')
+    if args.service_cidr is not None:
+        if ip_type == consts.IP_TYPE_IPV4:
+            validate_cidr(args.service_cidr, 'service_cidr', version=4)
+        elif ip_type in (consts.IP_TYPE_IPV6, consts.IP_TYPE_DUAL_STACK):
+            validate_cidr(args.service_cidr, 'service_cidr', version=6)
+        else:
+            validate_cidr(args.service_cidr, 'service_cidr')
+
+
+def get_config_ip_type(yaml_conf):
+    import yaml
+    if not path.isfile(yaml_conf):
+        return None
+    try:
+        with open(yaml_conf, 'r') as stream:
+            yaml_data = yaml.safe_load(stream) or {}
+    except yaml.YAMLError:
+        return None
+    pri = yaml_data.get(ocboot.GROUP_PRIMARY_MASTER_NODE, {})
+    ip_type = pri.get('ip_type')
+    if ip_type:
+        return ip_type
+    hostname = pri.get('hostname') or pri.get('node_ip')
+    if hostname:
+        match_ip, ip_type = match_ipaddr(hostname)
+        if match_ip:
+            return ip_type
+    return None
+
+
+def patch_config_cidrs(yaml_conf, pod_network_cidr=None, service_cidr=None,
+                       pod_network_cidr_v4=None, service_cidr_v4=None):
+    if not has_cidr_args(pod_network_cidr, service_cidr,
+                         pod_network_cidr_v4, service_cidr_v4):
+        return yaml_conf
+
+    import yaml
+    yaml_data = {}
+    try:
+        if path.isfile(yaml_conf) and path.getsize(yaml_conf) > 0:
+            with open(yaml_conf, 'r') as stream:
+                yaml_data = yaml.safe_load(stream) or {}
+    except yaml.YAMLError as exc:
+        pr_red("paring %s error: %s" % (yaml_conf, exc))
+        raise Exception("paring %s error: %s" % (yaml_conf, exc))
+
+    pri = yaml_data.get(ocboot.GROUP_PRIMARY_MASTER_NODE, {})
+    if not pri:
+        return yaml_conf
+
+    ip_type = pri.get('ip_type')
+    if not ip_type:
+        hostname = pri.get('hostname') or pri.get('node_ip')
+        if hostname:
+            match_ip, ip_type = match_ipaddr(hostname)
+            if not match_ip:
+                ip_type = consts.IP_TYPE_IPV4
+
+    changed = apply_cidr_to_config_dict(
+        pri,
+        ip_type=ip_type,
+        pod_network_cidr=pod_network_cidr,
+        service_cidr=service_cidr,
+        pod_network_cidr_v4=pod_network_cidr_v4,
+        service_cidr_v4=service_cidr_v4,
+    )
+    if changed:
+        yaml_data[ocboot.GROUP_PRIMARY_MASTER_NODE] = pri
+        with open(yaml_conf, 'w') as f:
+            f.write(yaml.dump(yaml_data))
+    return yaml_conf
+
+
 def generate_config(
     ipaddr, produc_stack,
     dns_list=[], runtime=consts.RUNTIME_QEMU,
     image_repository=None,
     region=consts.DEFAULT_REGION_NAME,
     zone=consts.DEFAULT_ZONE_NAME,
-    ip_dual_conf=None, ip_type=None, enable_ipip=False):
+    ip_dual_conf=None, ip_type=None, enable_ipip=False,
+    pod_network_cidr=None, service_cidr=None,
+    pod_network_cidr_v4=None, service_cidr_v4=None):
     global conf
     import os.path
     import os
@@ -424,6 +518,15 @@ def generate_config(
     if yaml_data.get(ocboot.GROUP_PRIMARY_MASTER_NODE, {}).get(ocboot.KEY_HOSTNAME, '') == ipaddr and \
             yaml_data.get(ocboot.GROUP_PRIMARY_MASTER_NODE, {}).get(ocboot.KEY_ONECLOUD_VERSION, '') == ver:
         update_config(temp, produc_stack, runtime)
+        if has_cidr_args(pod_network_cidr, service_cidr,
+                         pod_network_cidr_v4, service_cidr_v4):
+            patch_config_cidrs(
+                temp,
+                pod_network_cidr=pod_network_cidr,
+                service_cidr=service_cidr,
+                pod_network_cidr_v4=pod_network_cidr_v4,
+                service_cidr_v4=service_cidr_v4,
+            )
         pr_green(f"reuse conf: {temp}")
         return temp
 
@@ -501,6 +604,15 @@ def generate_config(
             extra_pri_dict['enable_ipip'] = enable_ipip
         extra_pri_dict['host_networks'] = f'{interface}/br0/{ipaddr}'
 
+    apply_cidr_to_config_dict(
+        extra_pri_dict,
+        ip_type=ip_type,
+        pod_network_cidr=pod_network_cidr,
+        service_cidr=service_cidr,
+        pod_network_cidr_v4=pod_network_cidr_v4,
+        service_cidr_v4=service_cidr_v4,
+    )
+
     if runtime == consts.RUNTIME_CONTAINERD:
         yaml_data[ocboot.GROUP_PRIMARY_MASTER_NODE].update({
             ocboot.KEY_ENABLE_CONTAINERD: True,
@@ -573,6 +685,14 @@ def inject_common_options(parser):
     parser.add_argument('--zone', type=str, dest='zone',
                        default=consts.DEFAULT_ZONE_NAME,
                        help=f"Default zone name: {consts.DEFAULT_ZONE_NAME}")
+    parser.add_argument('--pod-network-cidr-v4', dest='pod_network_cidr_v4', type=str, default=None,
+                       help='IPv4 pod network CIDR for dual-stack, e.g. 10.50.0.0/16')
+    parser.add_argument('--service-cidr-v4', dest='service_cidr_v4', type=str, default=None,
+                       help='IPv4 service network CIDR for dual-stack, e.g. 10.100.0.0/16')
+    parser.add_argument('--pod-network-cidr', dest='pod_network_cidr', type=str, default=None,
+                       help='Pod network CIDR (IPv6 for dual-stack, or primary for single-stack)')
+    parser.add_argument('--service-cidr', dest='service_cidr', type=str, default=None,
+                       help='Service network CIDR (IPv6 for dual-stack, or primary for single-stack)')
 
 
 def get_args():
@@ -692,6 +812,17 @@ def main():
         # 普通模式：使用用户指定的 runtime
         runtime = args.runtime
 
+    cidr_ip_type = ip_type
+    if not match_ip and path.isfile(ip_conf):
+        cidr_ip_type = get_config_ip_type(ip_conf) or ip_type
+    if has_cidr_args(args.pod_network_cidr, args.service_cidr,
+                     args.pod_network_cidr_v4, args.service_cidr_v4):
+        try:
+            validate_cli_cidrs(args, cidr_ip_type)
+        except Exception as e:
+            pr_red(str(e))
+            sys.exit(1)
+
     # 生成配置文件
     if match_ip:
         conf = generate_config(ip_conf, stackDict.get(stack),
@@ -700,9 +831,20 @@ def main():
                                args.region, args.zone,
                                ip_dual_conf=args.ip_dual_conf,
                                ip_type=ip_type,
-                               enable_ipip=args.enable_ipip)
+                               enable_ipip=args.enable_ipip,
+                               pod_network_cidr=args.pod_network_cidr,
+                               service_cidr=args.service_cidr,
+                               pod_network_cidr_v4=args.pod_network_cidr_v4,
+                               service_cidr_v4=args.service_cidr_v4)
     elif path.isfile(ip_conf) and path.getsize(ip_conf) > 0:
         conf = update_config(ip_conf, stackDict.get(stack), runtime)
+        conf = patch_config_cidrs(
+            conf,
+            pod_network_cidr=args.pod_network_cidr,
+            service_cidr=args.service_cidr,
+            pod_network_cidr_v4=args.pod_network_cidr_v4,
+            service_cidr_v4=args.service_cidr_v4,
+        )
     else:
         pr_red(f'The configuration file <{ip_conf}> does not exist or is not valid!')
         exit()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,3 +18,131 @@ class TestUtils(unittest.TestCase):
         self.assertTrue(utils.is_below_v3_9('v2.6.11'))
         self.assertFalse(utils.is_below_v3_9('v3.9.0'))
         self.assertFalse(utils.is_below_v3_9('master-test'))
+
+    def test_parse_ip(self):
+        self.assertIsNotNone(utils.parse_ip('10.0.0.1'))
+        self.assertIsNotNone(utils.parse_ip('fd85:ee78:d8a6:8607::1'))
+        self.assertIsNone(utils.parse_ip('127.0.0.1'))
+        self.assertIsNone(utils.parse_ip('my-hostname'))
+        self.assertIsNone(utils.parse_ip(None))
+
+    def test_ip_in_cidr_ipv4(self):
+        self.assertTrue(utils.ip_in_cidr('10.40.0.5', '10.40.0.0/16'))
+        self.assertFalse(utils.ip_in_cidr('10.0.0.5', '10.40.0.0/16'))
+        self.assertFalse(utils.ip_in_cidr('10.40.0.5', 'fd85:ee78:d8a6:8607::/56'))
+
+    def test_ip_in_cidr_ipv6(self):
+        self.assertTrue(utils.ip_in_cidr(
+            'fd85:ee78:d8a6:8607::1', 'fd85:ee78:d8a6:8607::/56'))
+        self.assertFalse(utils.ip_in_cidr(
+            '2001:db8::1', 'fd85:ee78:d8a6:8607::/56'))
+
+    def test_check_ips_against_cidrs_conflict(self):
+        ips = [('primary_master_node', '10.40.0.5')]
+        cidrs = [
+            ('pod_network_cidr', '10.40.0.0/16'),
+            ('service_cidr', '10.96.0.0/12'),
+        ]
+        errors = utils.check_ips_against_cidrs(ips, cidrs)
+        self.assertEqual(len(errors), 1)
+        self.assertIn('10.40.0.5', errors[0])
+        self.assertIn('pod_network_cidr', errors[0])
+
+    def test_check_ips_against_cidrs_no_conflict(self):
+        ips = [('primary_master_node', '10.0.0.5')]
+        cidrs = [
+            ('pod_network_cidr', '10.40.0.0/16'),
+            ('service_cidr', '10.96.0.0/12'),
+        ]
+        errors = utils.check_ips_against_cidrs(ips, cidrs)
+        self.assertEqual(errors, [])
+
+    def test_check_ips_against_cidrs_dual_stack(self):
+        ips = [
+            ('worker_node', '10.0.0.5'),
+            ('worker_node', 'fd85:ee78:d8a6:8607::1'),
+        ]
+        cidrs = [
+            ('pod_network_cidr', 'fd85:ee78:d8a6:8607::/56'),
+            ('service_cidr', 'fd85:ee78:d8a6:8608::/112'),
+            ('pod_network_cidr_v4', '10.40.0.0/16'),
+            ('service_cidr_v4', '10.96.0.0/12'),
+        ]
+        errors = utils.check_ips_against_cidrs(ips, cidrs)
+        self.assertEqual(len(errors), 1)
+        self.assertIn('fd85:ee78:d8a6:8607::1', errors[0])
+
+    def test_check_ips_against_cidrs_skips_hostname(self):
+        ips = [('worker_node', 'my-hostname')]
+        cidrs = [('pod_network_cidr', '10.40.0.0/16')]
+        errors = utils.check_ips_against_cidrs(ips, cidrs)
+        self.assertEqual(errors, [])
+
+    def test_check_ips_against_cidrs_invalid_cidr(self):
+        with self.assertRaises(Exception) as ctx:
+            utils.check_ips_against_cidrs(
+                [('node', '10.0.0.1')], [('pod_network_cidr', 'invalid')])
+        self.assertIn('Invalid CIDR format', str(ctx.exception))
+
+    def test_parse_k3s_network_cidrs(self):
+        config_yaml = """
+cluster-cidr: 10.40.0.0/16
+service-cidr: 10.96.0.0/12
+"""
+        cidrs = utils.parse_k3s_network_cidrs(config_yaml)
+        self.assertEqual(cidrs, [
+            ('pod_network_cidr', '10.40.0.0/16'),
+            ('service_cidr', '10.96.0.0/12'),
+        ])
+
+    def test_parse_k3s_network_cidrs_dual_stack(self):
+        config_yaml = """
+cluster-cidr: fd85:ee78:d8a6:8607::/56,10.40.0.0/16
+service-cidr: fd85:ee78:d8a6:8608::/112,10.96.0.0/12
+"""
+        cidrs = utils.parse_k3s_network_cidrs(config_yaml)
+        self.assertEqual(len(cidrs), 4)
+        self.assertIn(('pod_network_cidr', '10.40.0.0/16'), cidrs)
+        self.assertIn(('service_cidr', '10.96.0.0/12'), cidrs)
+
+    def test_validate_cidr_valid(self):
+        self.assertEqual(utils.validate_cidr('10.40.0.0/16', 'pod'), '10.40.0.0/16')
+        self.assertEqual(
+            utils.validate_cidr('fd85:ee78:d8a6:8607::/56', 'pod', version=6),
+            'fd85:ee78:d8a6:8600::/56')
+
+    def test_validate_cidr_invalid(self):
+        with self.assertRaises(Exception) as ctx:
+            utils.validate_cidr('invalid', 'pod_network_cidr')
+        self.assertIn('Invalid', str(ctx.exception))
+
+    def test_validate_cidr_wrong_version(self):
+        with self.assertRaises(Exception) as ctx:
+            utils.validate_cidr('10.40.0.0/16', 'pod_network_cidr', version=6)
+        self.assertIn('IPv6', str(ctx.exception))
+
+    def test_apply_cidr_to_config_dict_ipv4_single_stack(self):
+        config = {}
+        utils.apply_cidr_to_config_dict(
+            config,
+            ip_type='ipv4',
+            pod_network_cidr_v4='10.50.0.0/16',
+            service_cidr_v4='10.100.0.0/16',
+        )
+        self.assertEqual(config['pod_network_cidr_v4'], '10.50.0.0/16')
+        self.assertEqual(config['pod_network_cidr'], '10.50.0.0/16')
+        self.assertEqual(config['service_cidr'], '10.100.0.0/16')
+
+    def test_apply_cidr_to_config_dict_dual_stack(self):
+        config = {}
+        utils.apply_cidr_to_config_dict(
+            config,
+            ip_type='dual-stack',
+            pod_network_cidr='fd85:ee78:d8a6:8607::/56',
+            service_cidr='fd85:ee78:d8a6:8608::/112',
+            pod_network_cidr_v4='10.50.0.0/16',
+            service_cidr_v4='10.100.0.0/16',
+        )
+        self.assertEqual(config['pod_network_cidr'], 'fd85:ee78:d8a6:8607::/56')
+        self.assertEqual(config['pod_network_cidr_v4'], '10.50.0.0/16')
+        self.assertNotEqual(config.get('pod_network_cidr'), '10.50.0.0/16')


### PR DESCRIPTION
Validate pod/service CIDR CLI options during install config generation, and reject node IPs that overlap with pod or service networks on install and add-node.