### PR TITLE
fix: resolve and validate SSH private key before connection

### DIFF
--- a/lib/cluster.py
+++ b/lib/cluster.py
@@ -15,7 +15,7 @@ from .color import GB
 A_OCBOOT_UPGRADE_CURRENT_VERSION = 'upgrade.ocboot.yunion.io/current-version'
 
 
-def construct_cluster(primary_master_host, ssh_user, ssh_private_file, ssh_port):
+def resolve_ssh_private_file(ssh_private_file):
     if ssh_private_file is None or ssh_private_file == '':
         ssh_path = os.path.expanduser('~/.ssh')
         files = os.listdir(ssh_path)
@@ -25,8 +25,13 @@ def construct_cluster(primary_master_host, ssh_user, ssh_private_file, ssh_port)
                 break
     else:
         ssh_private_file = os.path.expanduser(ssh_private_file)
-    if not os.path.exists(ssh_private_file):
+    if not ssh_private_file or not os.path.exists(ssh_private_file):
         raise Exception(f"Private key file {ssh_private_file} not found")
+    return ssh_private_file
+
+
+def construct_cluster(primary_master_host, ssh_user, ssh_private_file, ssh_port):
+    ssh_private_file = resolve_ssh_private_file(ssh_private_file)
     cli = SSHClient(
         primary_master_host,
         ssh_user,

--- a/lib/service.py
+++ b/lib/service.py
@@ -15,7 +15,7 @@ from .parser import inject_ssh_hosts_options
 from . import utils
 from . import ansible
 from . import consts
-from .cluster import construct_cluster
+from .cluster import construct_cluster, resolve_ssh_private_file
 from .ocboot import WorkerConfig, Config
 from .ocboot import get_ansible_global_vars
 from .ocboot import KEY_ONECLOUD_VERSION
@@ -211,6 +211,7 @@ class AddNodesConfig(object):
                  enable_host_on_vm=False,
                  enable_lbagent=False,
                  **kwargs):
+        ssh_private_file = resolve_ssh_private_file(ssh_private_file)
         target_nodes = list(set(target_nodes))
         target_hostnames = [node.get_hostname() for node in cluster.k8s_nodes]
         self.enable_containerd = kwargs.get('runtime') == 'containerd'

--- a/lib/ssh.py
+++ b/lib/ssh.py
@@ -42,6 +42,11 @@ class SSHClient(object):
     def new_ssh_client(self):
 
         def cli_w(cmd):
+            private_key_file = self.get_private_key_file()
+            if not private_key_file:
+                raise Exception(
+                    "SSH private key file is not specified. "
+                    "Use --key-file/-k or place a key in ~/.ssh/")
             user_host = "%s@%s" % (self.get_user(), self.get_host())
             args = ["ssh",
                     "-p", str(self.get_port()),
@@ -49,7 +54,7 @@ class SSHClient(object):
                     "-o", "StrictHostKeyChecking=no",
                     "-o", "UserKnownHostsFile=/dev/null",
                     "-o", "ForwardX11=no",
-                    "-i", self.get_private_key_file(),
+                    "-i", private_key_file,
                     user_host,
                     cmd]
             debug_args = [x for x in args]


### PR DESCRIPTION
Extract resolve_ssh_private_file for reuse in AddNodesConfig and fail early with a clear error when no private key is found or specified.