### PR TITLE
Automated cherry pick of #1658: fix: skip k3s certificate rotate in renew-k3s-agent-certs

### DIFF
--- a/scripts/renew-k3s-agent-certs.sh
+++ b/scripts/renew-k3s-agent-certs.sh
@@ -33,13 +33,13 @@ if ! systemctl is-enabled k3s-agent &>/dev/null; then
     exit 1
 fi
 
-echo "[2/4] Stopping k3s-agent..."
+echo "[2/3] Stopping k3s-agent..."
 systemctl stop k3s-agent
 
-echo "[3/4] Rotating k3s agent certificates..."
-k3s certificate rotate
+#echo "[3/4] Rotating k3s agent certificates..."
+#k3s certificate rotate
 
-echo "[4/4] Starting k3s-agent..."
+echo "[3/3] Starting k3s-agent..."
 systemctl start k3s-agent
 
 sleep 5


### PR DESCRIPTION
Cherry pick of #1658 on release/4.0.

#1658: fix: skip k3s certificate rotate in renew-k3s-agent-certs