### PR TITLE
Automated cherry pick of #1661: fix: ceph.sh container use rand name

### DIFF
--- a/onecloud/roles/common/templates/ceph.sh.j2
+++ b/onecloud/roles/common/templates/ceph.sh.j2
@@ -32,11 +32,11 @@ if [ -z "$IMG" ]; then
         fi
     fi
 fi
-
+CTRNAME=ceph-common-$$-$RANDOM
 k3s ctr run --rm --net-host $TTY \
     --mount type=bind,src=/tmp,dst=/tmp,options=rbind \
     $IMG \
-    ceph-common \
+    $CTRNAME \
     /usr/bin/$CMD $@
 {% else %}
 if [ -t 0 ]; then


### PR DESCRIPTION
Cherry pick of #1661 on release/4.0.

#1661: fix: ceph.sh container use rand name