### PR TITLE
feat(ai-env): support external installer paths and improve GPU install flow

### DIFF
--- a/ocboot.sh
+++ b/ocboot.sh
@@ -68,16 +68,68 @@ if [[ $buildah_version_major -eq 1 ]] && [[ "$buildah_version_minor" -gt 23 ]]; 
 fi
 
 cmd_extra_args=""
-origin_args="$@"
+origin_args=()
 
-if [[ "$1" == "run.py" ]]; then
+normalize_installer_path() {
+    local path="$1"
+    if [[ "$path" == /* ]]; then
+        if [[ "$path" == "$(pwd)"/* ]] || [[ "$path" == "$(pwd)" ]]; then
+            if [[ "$path" == "$(pwd)" ]]; then
+                echo "$ROOT_DIR"
+            else
+                echo "$ROOT_DIR/${path#$(pwd)/}"
+            fi
+        else
+            echo "$path"
+        fi
+    else
+        path="${path#./}"
+        echo "$ROOT_DIR/$path"
+    fi
+}
+
+prev_arg=""
+for arg in "$@"; do
+    case "$prev_arg" in
+        --nvidia-driver-installer-path|--cuda-installer-path)
+            origin_args+=("$(normalize_installer_path "$arg")")
+            ;;
+        *)
+            origin_args+=("$arg")
+            ;;
+    esac
+    prev_arg="$arg"
+done
+
+if [[ "${origin_args[0]:-}" == "run.py" ]]; then
     if [[ "$IMAGE_REPOSITORY" != "$DEFAULT_REPO" ]]; then
         cmd_extra_args="$cmd_extra_args -i $IMAGE_REPOSITORY"
     fi
-    origin_args="$ROOT_DIR/$origin_args"
+    origin_args[0]="$ROOT_DIR/run.py"
 fi
 
 mkdir -p "$HOME/.kube"
+
+# Parse --nvidia-driver-installer-path and --cuda-installer-path from original args and
+# add bind-mounts so installer files outside $(pwd) are accessible in the container.
+extra_installer_volumes=()
+prev_arg=""
+declare -A mounted_installer_dirs
+for arg in "$@"; do
+    case "$prev_arg" in
+        --nvidia-driver-installer-path|--cuda-installer-path)
+            # Only handle absolute paths that are not already under $(pwd)
+            if [[ "$arg" == /* ]] && [[ "${arg#$(pwd)/}" == "$arg" ]] && [[ "$arg" != "$(pwd)" ]]; then
+                _dir="$(dirname "$arg")"
+                if [[ -z "${mounted_installer_dirs[$_dir]+x}" ]]; then
+                    extra_installer_volumes+=(-v "$_dir:$_dir:ro")
+                    mounted_installer_dirs[$_dir]=1
+                fi
+            fi
+            ;;
+    esac
+    prev_arg="$arg"
+done
 
 buildah run --isolation chroot --user $(id -u):$(id -g) \
     -t "${buildah_extra_args[@]}" \
@@ -89,4 +141,5 @@ buildah run --isolation chroot --user $(id -u):$(id -g) \
     -v "/etc/group:/etc/group:ro" \
     -v "$(pwd):$ROOT_DIR" \
     -v "$(pwd)/airgap_assets/k3s-install.sh:/airgap_assets/k3s-install.sh:ro" \
-    "$CONTAINER_NAME" $CMD $origin_args $cmd_extra_args
+    "${extra_installer_volumes[@]}" \
+    "$CONTAINER_NAME" $CMD "${origin_args[@]}" $cmd_extra_args

--- a/onecloud/roles/utils/ai-env/tasks/check-gpu-and-driver.yml
+++ b/onecloud/roles/utils/ai-env/tasks/check-gpu-and-driver.yml
@@ -26,10 +26,35 @@
   register: cuda_check
   changed_when: false
   failed_when: false
+  when: cuda_installer_path is defined
 
 - name: Set CUDA installation flag
   set_fact:
     cuda_installed: "{{ cuda_check.rc == 0 }}"
+  when: cuda_installer_path is defined
+
+- name: Assume CUDA ready when installer path not provided
+  set_fact:
+    cuda_installed: true
+  when: cuda_installer_path is not defined
+
+- name: Check if nvidia-drm.modeset=1 is in GRUB_CMDLINE_LINUX
+  shell: grep -q "nvidia-drm.modeset=1" /etc/default/grub
+  register: grub_modeset_check
+  changed_when: false
+  failed_when: false
+
+- name: Set GRUB readiness flag
+  set_fact:
+    ai_env_grub_ready: "{{ grub_modeset_check.rc == 0 }}"
+
+- name: Set full AI env readiness flag
+  set_fact:
+    ai_env_fully_ready: "{{
+      (nvidia_driver_installed | default(false)) and
+      (cuda_installed | default(false)) and
+      (ai_env_grub_ready | default(false))
+    }}"
 
 - name: Fail when driver not installed and no installer path provided
   fail:

--- a/onecloud/roles/utils/ai-env/tasks/install-cuda.yml
+++ b/onecloud/roles/utils/ai-env/tasks/install-cuda.yml
@@ -102,4 +102,15 @@
   - debug: var=cuda_install_result.stdout_lines
   - debug: var=cuda_verify_result.stdout_lines
 
+  - name: Reboot after CUDA installation
+    reboot:
+      msg: "Reboot initiated by Ansible after CUDA installation"
+      connect_timeout: 5
+      reboot_timeout: 600
+      pre_reboot_delay: 0
+      post_reboot_delay: 30
+      test_command: whoami
+    become: true
+    when: cuda_install_result is defined and cuda_install_result.changed | default(false)
+
   when: not cuda_installed | default(false)

--- a/onecloud/roles/utils/ai-env/tasks/install-nvidia-driver-Debian.yml
+++ b/onecloud/roles/utils/ai-env/tasks/install-nvidia-driver-Debian.yml
@@ -1,13 +1,21 @@
-- name: Install kernel headers and development packages for current kernel
-  shell: |
-    KERNEL_VERSION="{{ current_kernel_version.stdout }}"
-    apt-get update && \
-    apt-get install -y linux-headers-${KERNEL_VERSION} || \
-    apt-get install -y {{ kernel_package }} {{ kernel_headers_package }} {{ kernel_devel_package }}
-  become: true
-  args:
-    executable: /bin/bash
-  register: kernel_install_result
+- block:
+  - name: Install linux headers for current kernel
+    package:
+      name: "linux-headers-{{ current_kernel_version.stdout }}"
+      state: present
+      update_cache: true
+    register: kernel_install_result
+    become: true
+  rescue:
+  - name: Install linux headers (fallback)
+    package:
+      name:
+        - "{{ kernel_headers_package }}"
+        - "{{ kernel_devel_package }}"
+      state: present
+      update_cache: true
+    register: kernel_install_result
+    become: true
 
 - name: Install build tools
   package:

--- a/onecloud/roles/utils/ai-env/tasks/install-nvidia-driver-RedHat.yml
+++ b/onecloud/roles/utils/ai-env/tasks/install-nvidia-driver-RedHat.yml
@@ -1,13 +1,21 @@
-- name: Install kernel headers and development packages for current kernel
-  shell: |
-    KERNEL_VERSION="{{ current_kernel_version.stdout }}"
-    yum install -y kernel-headers-${KERNEL_VERSION} kernel-devel-${KERNEL_VERSION} || \
-    yum install -y "kernel-headers-${KERNEL_VERSION}" "kernel-devel-${KERNEL_VERSION}" || \
-    yum install -y {{ kernel_package }} {{ kernel_headers_package }} {{ kernel_devel_package }}
-  become: true
-  args:
-    executable: /bin/bash
-  register: kernel_install_result
+- block:
+  - name: Install kernel headers and development packages for current kernel
+    package:
+      name:
+        - "kernel-headers-{{ current_kernel_version.stdout }}"
+        - "kernel-devel-{{ current_kernel_version.stdout }}"
+      state: present
+    register: kernel_install_result
+    become: true
+  rescue:
+  - name: Install kernel headers and development packages (fallback)
+    package:
+      name:
+        - "{{ kernel_headers_package }}"
+        - "{{ kernel_devel_package }}"
+      state: present
+    register: kernel_install_result
+    become: true
 
 - name: Install build tools (gcc, make, etc.)
   package:

--- a/onecloud/roles/utils/ai-env/tasks/install-nvidia-driver.yml
+++ b/onecloud/roles/utils/ai-env/tasks/install-nvidia-driver.yml
@@ -85,7 +85,7 @@
     post_reboot_delay: 30
     test_command: whoami
   become: true
-  when: kernel_install_result.changed or nouveau_blacklisted.changed or grub_vfio_removed.changed or grub_iommu_removed.changed
+  when: nouveau_blacklisted.changed or grub_vfio_removed.changed or grub_iommu_removed.changed
 
 - name: Check if NVIDIA driver is already installed
   shell: nvidia-smi
@@ -166,5 +166,16 @@
     when: kernel_source_path | default('') == ''
 
   - debug: var=nvidia_install_result.stdout_lines
+
+  - name: Reboot after NVIDIA driver installation
+    reboot:
+      msg: "Reboot initiated by Ansible after NVIDIA driver installation"
+      connect_timeout: 5
+      reboot_timeout: 600
+      pre_reboot_delay: 0
+      post_reboot_delay: 30
+      test_command: whoami
+    become: true
+    when: nvidia_install_result is defined and nvidia_install_result.changed | default(false)
 
   when: not nvidia_driver_installed | default(false)

--- a/onecloud/roles/utils/ai-env/tasks/main.yml
+++ b/onecloud/roles/utils/ai-env/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: Check NVIDIA GPU and driver/CUDA status on target host
   include_tasks: check-gpu-and-driver.yml
-  when: nvidia_driver_installer_path is defined and cuda_installer_path is defined
+  when: nvidia_driver_installer_path is defined
 
 - name: Check local installation files
   include_tasks: check-local-files.yml
@@ -11,7 +11,9 @@
 
 - name: Install NVIDIA driver (if installer path provided)
   include_tasks: install-nvidia-driver.yml
-  when: nvidia_driver_installer_path is defined
+  when: >
+    nvidia_driver_installer_path is defined and
+    not (ai_env_fully_ready | default(false))
 
 - name: Install CUDA (if installer path provided)
   include_tasks: install-cuda.yml


### PR DESCRIPTION
- Bind-mount external nvidia/cuda installer directories in ocboot.sh
- Add GRUB readiness check and skip install when environment is fully ready
- Reboot after driver/CUDA installation; refactor kernel headers install