### PR TITLE
fix(upgrade): 先升级 operator 再升级 OnecloudCluster，并按目标版本等待服务就绪

### DIFF
--- a/lib/cluster.py
+++ b/lib/cluster.py
@@ -12,8 +12,6 @@ from .k3s import is_using_k3s
 from .ocboot import GROUP_PRIMARY_MASTER_NODE, GROUP_MASTER_NODES, GROUP_WORKER_NODES
 from .color import GB
 
-A_OCBOOT_UPGRADE_CURRENT_VERSION = 'upgrade.ocboot.yunion.io/current-version'
-
 
 def resolve_ssh_private_file(ssh_private_file):
     if ssh_private_file is None or ssh_private_file == '':
@@ -112,9 +110,6 @@ class OnecloudCluster(object):
         return (repo, IPADDR_REG.match(repo) is not None)
 
     def get_current_version(self):
-        version = self.get_annotations().get(A_OCBOOT_UPGRADE_CURRENT_VERSION, None)
-        if version:
-            return version
         return self.get_spec().get('version')
 
     def _construct_nodes(self):
@@ -156,12 +151,6 @@ class OnecloudCluster(object):
             add_i(AnsibleWorkerHost(node, port=node_port))
 
         return inventory.generate_content()
-
-    def set_current_version(self, version):
-        k3s_cmd_placeholder = 'k3s' if self.is_using_k3s() else ''
-        cmd = f'{k3s_cmd_placeholder} kubectl -n onecloud annotate --overwrite=true onecloudclusters default {A_OCBOOT_UPGRADE_CURRENT_VERSION}={version}'
-        print(GB(cmd))
-        self.ssh_client.exec_command(cmd, self.use_sudo())
 
 
 class AnsibleInventory(object):

--- a/lib/upgrade.py
+++ b/lib/upgrade.py
@@ -33,10 +33,10 @@ UPGRADE_MODES_ROLE_FILE = {
 }
 
 UPGRADE_MODES_FINISH_MSG = {
-    UPGRADE_MODES_UPGRADE: "The system has been upgraded to the latest version.",
-    UPGRADE_MODES_UPGRADE_CONTROLLER: "The Controller has been upgraded to the latest version.",
-    UPGRADE_MODES_UPGRADE_HOST: "Worker nodes have been upgraded to the latest version.",
-    UPGRADE_MODES_UPGRADE_FINAL: "The final step of the upgraded is now finished.",
+    UPGRADE_MODES_UPGRADE: "The system has been upgraded to {version}.",
+    UPGRADE_MODES_UPGRADE_CONTROLLER: "The Controller has been upgraded to {version}.",
+    UPGRADE_MODES_UPGRADE_HOST: "Worker nodes have been upgraded to {version}.",
+    UPGRADE_MODES_UPGRADE_FINAL: "The final step of the upgrade to {version} is now finished.",
 }
 
 
@@ -101,6 +101,12 @@ def add_command(subparsers, command="upgrade"):
                         action="store_true",
                         default=False,
                         help="re-init gpu druing upgrading. default: false.")
+
+    parser.add_argument("--allow-errors",
+                        dest="allow_errors",
+                        action="store_true",
+                        default=False,
+                        help="disable any_errors_fatal so other hosts continue after some hosts fail (default: false)")
 
     if command == UPGRADE_MODES_UPGRADE_HOST:
         parser.add_argument("--hosts", "-H",
@@ -168,6 +174,18 @@ def do_upgrade(args):
     if not args.gpu_init:
         vars['upgrade_without_gpu'] = True
 
+    # Ansible cannot reliably template play-level any_errors_fatal (Jinja always
+    # yields a string; non-empty strings are treated as true). Strip the keyword
+    # from a temp playbook so Ansible uses its default (continue on host failure).
+    # Keep the file beside the original playbook so relative roles/ paths resolve.
+    if args.allow_errors:
+        with open(playbook_file) as f:
+            playbook_lines = f.readlines()
+        playbook_file = os.path.join(
+            os.path.dirname(playbook_file), 'upgrade-cluster-allow-errors.yml')
+        with open(playbook_file, 'w') as f:
+            f.writelines(line for line in playbook_lines if 'any_errors_fatal' not in line)
+
     return_code = run_ansible_playbook(
         inventory_f,
         playbook_file,
@@ -176,8 +194,8 @@ def do_upgrade(args):
 
     if return_code is not None and return_code != 0:
         return return_code
-    cluster.set_current_version(args.version)
-    utils.pr_green('\n' + UPGRADE_MODES_FINISH_MSG.get(args.subcmd) + '\n')
+    finish_msg = UPGRADE_MODES_FINISH_MSG.get(args.subcmd, '').format(version=args.version)
+    utils.pr_green('\n' + finish_msg + '\n')
 
 
 class UpgradeConfig(object):

--- a/onecloud/roles/upgrade/primary_master_node/tasks/main.yml
+++ b/onecloud/roles/upgrade/primary_master_node/tasks/main.yml
@@ -83,73 +83,13 @@
   include_role:
     name: utils/onecloud-waiter
 
-# use async task to upgrade, ref: https://docs.ansible.com/ansible/latest/user_guide/playbooks_async.html
-- name: primary master node | Upgrade version "{{ current_onecloud_version }}" to "{{ upgrade_onecloud_version }}"
-  environment:
-    KUBECONFIG: "{{ ENV_KUBECONFIG }}"
-    PATH: /opt/yunion/bin:{{ ansible_env.PATH }}
-  args:
-    executable: /bin/bash
-  shell: |
-    edition=$(KUBECONFIG="{{ ENV_KUBECONFIG }}" {{ K3S_CMDLINE_PREFIX }} kubectl -n onecloud get oc -o jsonpath='{.items[0].metadata.annotations.onecloud\.yunion\.io/edition}' || :)
-    if [[ "$edition" == "ee" ]]; then
-      /opt/yunion/bin/climc-ee update-record-create --version {{ upgrade_onecloud_version }} \
-        --registry {{ image_repository | default('registry.cn-beijing.aliyuncs.com/yunion')}} || :
-    fi
+# Upgrade operator first; only then patch OnecloudCluster spec.version.
+# Ref: https://docs.ansible.com/ansible/latest/user_guide/playbooks_async.html
+- name: primary master node | Upgrade operator
+  include_tasks: upgrade_operator.yml
 
-    KUBECONFIG="{{ ENV_KUBECONFIG }}" {{ K3S_CMDLINE_PREFIX }} kubectl -n onecloud patch deployment onecloud-operator --type=json \
-      -p '[
-        {"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "{{ image_repository | default('registry.cn-beijing.aliyuncs.com/yunion')}}/onecloud-operator:{{ upgrade_onecloud_version }}"},
-        {"op": "replace", "path": "/spec/template/spec/containers/0/command", "value": ["/bin/onecloud-controller-manager", "-disable-init-crd", "-clear-component"]} ## disable-init-cr
-      ]'
-
-    bash /opt/yunion/bin/wait-onecloud-services.sh "onecloud-operator"
-
-    KUBECONFIG="{{ ENV_KUBECONFIG }}" {{ K3S_CMDLINE_PREFIX }} kubectl patch onecloudclusters -n onecloud default --type merge --patch '
-    {
-      "spec": {
-        "version": "{{ upgrade_onecloud_version }}",
-        "imageRepository": "{{ image_repository | default('registry.cn-beijing.aliyuncs.com/yunion')}}"
-      }
-    }'
-    # delete annotation for autoupdate.onecloud.yunion.io/current-version
-    KUBECONFIG="{{ ENV_KUBECONFIG }}" {{ K3S_CMDLINE_PREFIX }} kubectl patch onecloudclusters -n onecloud default --type merge --patch '
-      {
-        "metadata": {
-          "annotations": {
-            "autoupdate.onecloud.yunion.io/current-version": null
-          }
-        },
-        "spec": {
-          "autoupdate": {
-            "tag": ""
-          },
-          "hostagent": {
-            "tag": ""
-          }
-        }
-      }
-    '
-    KUBECONFIG="{{ ENV_KUBECONFIG }}" {{ K3S_CMDLINE_PREFIX }} kubectl rollout restart deployment -n onecloud onecloud-operator
-    bash /opt/yunion/bin/wait-onecloud-services.sh
-  # 30 minutes timeout
-  become: yes
-  async: 1800
-  poll: 0
-  register: upgrade_status
-
-- name: >
-    primary master node | Check upgrade async task.
-    To watch upgrade process,
-    SSH login host "{{ ansible_hostname }}" execute:
-      kubectl get pods -n onecloud -w
-  become: yes
-  async_status:
-    jid: "{{ upgrade_status.ansible_job_id }}"
-  register: ocadm_update_result
-  until: ocadm_update_result.finished
-  retries: 30
-  delay: 60
+- name: primary master node | Upgrade OnecloudCluster
+  include_tasks: upgrade_oc.yml
 
 - name: Copy turn-off-operator-clear-component patch to /tmp/turn-off-operator-clear-component.patch.yml
   template:

--- a/onecloud/roles/upgrade/primary_master_node/tasks/upgrade_oc.yml
+++ b/onecloud/roles/upgrade/primary_master_node/tasks/upgrade_oc.yml
@@ -1,0 +1,55 @@
+# Upgrade OnecloudCluster: set spec.version only after operator is ready.
+- name: primary master node | Upgrade OnecloudCluster "{{ current_onecloud_version }}" to "{{ upgrade_onecloud_version }}"
+  environment:
+    KUBECONFIG: "{{ ENV_KUBECONFIG }}"
+    PATH: /opt/yunion/bin:{{ ansible_env.PATH }}
+  args:
+    executable: /bin/bash
+  shell: |
+    KUBECONFIG="{{ ENV_KUBECONFIG }}" {{ K3S_CMDLINE_PREFIX }} kubectl patch onecloudclusters -n onecloud default --type merge --patch '
+    {
+      "spec": {
+        "version": "{{ upgrade_onecloud_version }}",
+        "imageRepository": "{{ image_repository | default('registry.cn-beijing.aliyuncs.com/yunion')}}"
+      }
+    }'
+    # delete legacy current-version annotations (ocboot / autoupdate)
+    KUBECONFIG="{{ ENV_KUBECONFIG }}" {{ K3S_CMDLINE_PREFIX }} kubectl patch onecloudclusters -n onecloud default --type merge --patch '
+      {
+        "metadata": {
+          "annotations": {
+            "upgrade.ocboot.yunion.io/current-version": null,
+            "autoupdate.onecloud.yunion.io/current-version": null
+          }
+        },
+        "spec": {
+          "autoupdate": {
+            "tag": ""
+          },
+          "hostagent": {
+            "tag": ""
+          }
+        }
+      }
+    '
+    KUBECONFIG="{{ ENV_KUBECONFIG }}" {{ K3S_CMDLINE_PREFIX }} kubectl rollout restart deployment -n onecloud onecloud-operator
+    KUBECONFIG="{{ ENV_KUBECONFIG }}" {{ K3S_CMDLINE_PREFIX }} kubectl -n onecloud rollout status deployment/onecloud-operator --timeout=1800s
+    # EXPECT_VERSION: do not return early while old service pods are still Running.
+    EXPECT_VERSION="{{ upgrade_onecloud_version }}" bash /opt/yunion/bin/wait-onecloud-services.sh
+  become: yes
+  async: 1800
+  poll: 0
+  register: upgrade_oc_status
+
+- name: >
+    primary master node | Check OnecloudCluster upgrade async task.
+    To watch upgrade process,
+    SSH login host "{{ ansible_hostname }}" execute:
+      kubectl get pods -n onecloud -w
+  become: yes
+  async_status:
+    jid: "{{ upgrade_oc_status.ansible_job_id }}"
+  register: upgrade_oc_result
+  until: upgrade_oc_result.finished
+  retries: 30
+  delay: 60

--- a/onecloud/roles/upgrade/primary_master_node/tasks/upgrade_operator.yml
+++ b/onecloud/roles/upgrade/primary_master_node/tasks/upgrade_operator.yml
@@ -1,0 +1,40 @@
+# Upgrade operator only; do not patch OnecloudCluster spec.version here.
+- name: primary master node | Upgrade operator to "{{ upgrade_onecloud_version }}"
+  environment:
+    KUBECONFIG: "{{ ENV_KUBECONFIG }}"
+    PATH: /opt/yunion/bin:{{ ansible_env.PATH }}
+  args:
+    executable: /bin/bash
+  shell: |
+    edition=$(KUBECONFIG="{{ ENV_KUBECONFIG }}" {{ K3S_CMDLINE_PREFIX }} kubectl -n onecloud get oc -o jsonpath='{.items[0].metadata.annotations.onecloud\.yunion\.io/edition}' || :)
+    if [[ "$edition" == "ee" ]]; then
+      /opt/yunion/bin/climc-ee update-record-create --version {{ upgrade_onecloud_version }} \
+        --registry {{ image_repository | default('registry.cn-beijing.aliyuncs.com/yunion')}} || :
+    fi
+
+    KUBECONFIG="{{ ENV_KUBECONFIG }}" {{ K3S_CMDLINE_PREFIX }} kubectl -n onecloud patch deployment onecloud-operator --type=json \
+      -p '[
+        {"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "{{ image_repository | default('registry.cn-beijing.aliyuncs.com/yunion')}}/onecloud-operator:{{ upgrade_onecloud_version }}"},
+        {"op": "replace", "path": "/spec/template/spec/containers/0/command", "value": ["/bin/onecloud-controller-manager", "-disable-init-crd", "-clear-component"]}
+      ]'
+
+    # rollout status waits for new RS; EXPECT_VERSION avoids returning on old Running pods.
+    KUBECONFIG="{{ ENV_KUBECONFIG }}" {{ K3S_CMDLINE_PREFIX }} kubectl -n onecloud rollout status deployment/onecloud-operator --timeout=1800s
+    EXPECT_VERSION="{{ upgrade_onecloud_version }}" bash /opt/yunion/bin/wait-onecloud-services.sh "onecloud-operator"
+  become: yes
+  async: 1800
+  poll: 0
+  register: upgrade_operator_status
+
+- name: >
+    primary master node | Check operator upgrade async task.
+    To watch upgrade process,
+    SSH login host "{{ ansible_hostname }}" execute:
+      kubectl get pods -n onecloud -w
+  become: yes
+  async_status:
+    jid: "{{ upgrade_operator_status.ansible_job_id }}"
+  register: upgrade_operator_result
+  until: upgrade_operator_result.finished
+  retries: 30
+  delay: 60

--- a/onecloud/roles/utils/onecloud-waiter/tasks/main.yml
+++ b/onecloud/roles/utils/onecloud-waiter/tasks/main.yml
@@ -5,5 +5,6 @@
     mode: '0755'
   vars:
     ENV_KUBECONFIG: "{{ ENV_KUBECONFIG | default('/etc/kubernetes/admin.conf') }}"
-    K3S_CMDLINE_PREFIX: "{{ K3S_CMDLINE_PREFIX | default('k8s') }}"
+    # empty for kubeadm/k8s; "k3s" (or full path) when using k3s — never "k8s"
+    K3S_CMDLINE_PREFIX: "{{ K3S_CMDLINE_PREFIX | default('') }}"
 

--- a/onecloud/roles/utils/onecloud-waiter/templates/wait-onecloud-services.sh.j2
+++ b/onecloud/roles/utils/onecloud-waiter/templates/wait-onecloud-services.sh.j2
@@ -1,6 +1,22 @@
 #!/bin/bash
 
-export KUBECONFIG="{{ ENV_KUBECONFIG }}"
+_OC_KUBECONFIG="{{ ENV_KUBECONFIG }}"
+_OC_KUBECTL_PREFIX="{{ K3S_CMDLINE_PREFIX }}"
+
+if [[ -n "$_OC_KUBECONFIG" && -f "$_OC_KUBECONFIG" ]]; then
+	export KUBECONFIG="$_OC_KUBECONFIG"
+elif [[ -z "${KUBECONFIG:-}" ]]; then
+	for f in /etc/kubernetes/admin.conf /etc/rancher/k3s/k3s.yaml "${HOME}/.kube/config"; do
+		if [[ -f "$f" ]]; then
+			export KUBECONFIG="$f"
+			break
+		fi
+	done
+fi
+
+# Optional: EXPECT_VERSION=v4.0.0 — also require pod images contain this tag.
+# Used by upgrade so we do not return early on old still-Running pods.
+EXPECT_VERSION="${EXPECT_VERSION:-}"
 
 services=(
 	keystone
@@ -10,38 +26,111 @@ services=(
 	onecloud-operator
 )
 
+kubectl_cmd() {
+	if [[ -n "$_OC_KUBECTL_PREFIX" ]]; then
+		$_OC_KUBECTL_PREFIX kubectl "$@"
+	else
+		kubectl "$@"
+	fi
+}
+
+pod_label_key() {
+	local svc="$1"
+	if [ "$svc" == "onecloud-operator" ]; then
+		echo "k8s-app"
+	else
+		echo "app"
+	fi
+}
+
+# stdout: "true" or "false" only; diagnostics go to stderr.
 check_svc() {
 	local svc="$1"
-	local key="app"
-	if [ "$svc" == "onecloud-operator" ]; then
-		key="k8s-app"
-	fi
-	local status=$({{ K3S_CMDLINE_PREFIX }} kubectl get pods -n onecloud -l $key=$svc | grep "$svc" | grep -v Terminating | awk '{print $3}' | sort -u | xargs)
-	if [[ "$status" == "Running" ]]; then
-		echo "true"
-	else
-		echo "service pod $svc status is $status"
+	local key
+	key="$(pod_label_key "$svc")"
+
+	local pods kubectl_err
+	kubectl_err="$(mktemp)"
+	pods="$(kubectl_cmd get pods -n onecloud -l "$key=$svc" --no-headers 2>"$kubectl_err" | grep -v Terminating || true)"
+	if [[ -z "$pods" ]]; then
+		if [[ -s "$kubectl_err" ]]; then
+			echo "kubectl failed while listing pod $svc (KUBECONFIG=${KUBECONFIG:-unset}):" >&2
+			cat "$kubectl_err" >&2
+		else
+			echo "service pod $svc not found" >&2
+		fi
+		rm -f "$kubectl_err"
 		echo "false"
+		return
 	fi
+	rm -f "$kubectl_err"
+
+	# READY must be N/N (N>0) and STATUS must be Running for every pod.
+	# Note: awk regex does not support backreferences; compare split READY fields.
+	local not_ready
+	not_ready="$(echo "$pods" | awk '{
+		n = split($2, a, "/")
+		if ($3 != "Running" || n != 2 || a[1]+0 == 0 || a[1]+0 != a[2]+0) print
+	}')"
+	if [[ -n "$not_ready" ]]; then
+		echo "service pod $svc not ready:" >&2
+		echo "$not_ready" >&2
+		echo "false"
+		return
+	fi
+
+	# During upgrade, old pods can still be Running; require image tag match.
+	if [[ -n "$EXPECT_VERSION" ]]; then
+		local name images matched=0
+		# jsonpath braces must stay literal for kubectl; keep outside Jinja parsing.
+		local jp
+		jp='{% raw %}{range .spec.containers[*]}{.image}{"\n"}{end}{% endraw %}'
+		while read -r name _; do
+			[[ -z "$name" ]] && continue
+			images="$(kubectl_cmd get pod -n onecloud "$name" -o jsonpath="$jp" 2>/dev/null || true)"
+			if echo "$images" | grep -Fq ":${EXPECT_VERSION}"; then
+				matched=1
+			else
+				echo "service pod $name image not yet ${EXPECT_VERSION}, current:" >&2
+				echo "$images" >&2
+				echo "false"
+				return
+			fi
+		done <<< "$pods"
+		if [[ "$matched" -ne 1 ]]; then
+			echo "service pod $svc has no image with tag ${EXPECT_VERSION}" >&2
+			echo "false"
+			return
+		fi
+	fi
+
+	echo "true"
 }
 
 wait_svc() {
 	local svc="$1"
-	local is_running=$(check_svc "$svc")
+	local is_running
+	is_running="$(check_svc "$svc")"
 	sleep 1
 	while true; do
-		if [[ $is_running == "true" ]]; then
+		if [[ "$is_running" == "true" ]]; then
 			echo "service pod $svc is running"
 			return
 		else
 			echo "continue waiting service pod $svc, sleep 30s"
-			is_running=$(check_svc "$svc")
+			is_running="$(check_svc "$svc")"
 			sleep 30
 		fi
 	done
 }
 
-for svc in ${@:-${services[@]}}; do
-	echo "waiting service pod $svc to be running"
+if [[ $# -gt 0 ]]; then
+	svcs=("$@")
+else
+	svcs=("${services[@]}")
+fi
+
+for svc in "${svcs[@]}"; do
+	echo "waiting service pod $svc to be running${EXPECT_VERSION:+ (version $EXPECT_VERSION)}"
 	wait_svc "$svc"
 done

--- a/onecloud/upgrade-cluster.yml
+++ b/onecloud/upgrade-cluster.yml
@@ -1,26 +1,32 @@
 - hosts: all
+  any_errors_fatal: true
   roles:
     - { role: utils/detect-os }
     - { role: common }
     - { role: upgrade/common }
 
 - hosts: primary_master_node
+  any_errors_fatal: true
   roles:
     - { role: upgrade/primary_master_node }
     - { role: utils/k8s/addons }
 
 - hosts: master_nodes
+  any_errors_fatal: true
   roles:
     - { role: upgrade/master_nodes }
 
 - hosts: worker_nodes
+  any_errors_fatal: true
   roles:
     - { role: upgrade/worker_nodes }
 
 - hosts: primary_master_node:master_nodes
+  any_errors_fatal: true
   roles:
     - { role: utils/k8s/apiserver/args }
 
 - hosts: primary_master_node:master_nodes:worker_nodes
+  any_errors_fatal: true
   roles:
     - { role: utils/gpu-init }


### PR DESCRIPTION
拆分 primary master 升级流程，修正 waiter 的就绪判定与 KUBECONFIG/kubectl 前缀，移除冗余的 current-version annotation。