### PR TITLE
feat(ai-env): 未指定虚拟设备数时默认使用 HAMi

### DIFF
--- a/lib/add_node.py
+++ b/lib/add_node.py
@@ -56,7 +56,7 @@ class AddWorkerNodeService(AddNodeService):
             'ip_type': args.ip_type,
             'offline_data_path': args.offline_data_path,
             'enable_ai_env': getattr(args, 'enable_ai_env', False),
-            'gpu_device_virtual_number': getattr(args, 'gpu_device_virtual_number', 2),
+            'gpu_device_virtual_number': getattr(args, 'gpu_device_virtual_number', None),
             'nvidia_driver_installer_path': getattr(args, 'nvidia_driver_installer_path', None),
             'cuda_installer_path': getattr(args, 'cuda_installer_path', None),
         }

--- a/lib/parser.py
+++ b/lib/parser.py
@@ -121,8 +121,8 @@ def inject_ai_nvidia_options(parser):
     parser.add_argument("--gpu-device-virtual-number",
                         dest="gpu_device_virtual_number",
                         type=int,
-                        default=2,
-                        help=help_d("Virtual number for NVIDIA GPU share device (default: 2)"))
+                        default=None,
+                        help=help_d("Virtual number for NVIDIA GPU share device. If omitted, GPUs use HAMi by default"))
 
 
 def inject_auto_backup_options(parser):

--- a/lib/service.py
+++ b/lib/service.py
@@ -279,7 +279,7 @@ class AddNodesConfig(object):
         self.node_ip_v6 = kwargs.get("node_ip_v6", None)
 
         self.enable_ai_env = kwargs.get('enable_ai_env', False)
-        self.gpu_device_virtual_number = kwargs.get('gpu_device_virtual_number', 2)
+        self.gpu_device_virtual_number = kwargs.get('gpu_device_virtual_number', None)
         self.nvidia_driver_installer_path = kwargs.get('nvidia_driver_installer_path')
         self.cuda_installer_path = kwargs.get('cuda_installer_path')
 
@@ -348,7 +348,8 @@ class AddNodesConfig(object):
 
         if self.enable_ai_env:
             vars['enable_ai_env'] = True
-            vars['gpu_device_virtual_number'] = self.gpu_device_virtual_number
+            if self.gpu_device_virtual_number is not None:
+                vars['gpu_device_virtual_number'] = self.gpu_device_virtual_number
             if self.nvidia_driver_installer_path:
                 vars['nvidia_driver_installer_path'] = self.nvidia_driver_installer_path
             if self.cuda_installer_path:

--- a/lib/setup_ai_env.py
+++ b/lib/setup_ai_env.py
@@ -28,8 +28,8 @@ class AIEnvService(BaseService):
         parser.add_argument("--gpu-device-virtual-number",
                            dest="gpu_device_virtual_number",
                            type=int,
-                           default=2,
-                           help=help_d("Virtual number for NVIDIA GPU share device (default: 2)"))
+                           default=None,
+                           help=help_d("Virtual number for NVIDIA GPU share device. If omitted, GPUs use HAMi by default"))
 
     def do_action(self, args):
         config = NodesConfig(args.target_node_hosts,
@@ -41,10 +41,11 @@ class AIEnvService(BaseService):
         vars = {
             'nvidia_driver_installer_path': args.nvidia_driver_installer_path,
             'cuda_installer_path': args.cuda_installer_path,
-            'gpu_device_virtual_number': args.gpu_device_virtual_number,
             # Add SSH configuration for rsync commands
             'ansible_ssh_private_key_file': args.ssh_private_file,
         }
+        if args.gpu_device_virtual_number is not None:
+            vars['gpu_device_virtual_number'] = args.gpu_device_virtual_number
         
         return config.run(self.action, vars=vars)
 

--- a/onecloud/roles/utils/ai-env/README.md
+++ b/onecloud/roles/utils/ai-env/README.md
@@ -39,7 +39,7 @@ ocboot.py setup-ai-env <target_host1> <target_host2> ... \
 
 - `--nvidia-driver-installer-path` (必需): NVIDIA 驱动安装包的完整路径，例如 `/root/nvidia/NVIDIA-Linux-x86_64-570.133.07.run`
 - `--cuda-installer-path` (必需): CUDA 安装包的完整路径，例如 `/root/nvidia/cuda_12.8.1_570.124.06_linux.run`
-- `--gpu-device-virtual-number` (可选): NVIDIA GPU 共享设备的虚拟编号，默认为 2
+- `--gpu-device-virtual-number` (可选): NVIDIA GPU 共享设备的虚拟编号。未指定时默认使用 HAMi；指定后才会生成 `NVIDIA_GPU_SHARE` 虚拟设备
 - `--user`, `-u` (可选): SSH 用户名，默认为 root
 - `--key-file`, `-k` (可选): SSH 私钥文件路径
 - `--port`, `-p` (可选): SSH 端口，默认为 22
@@ -52,7 +52,7 @@ ocboot.py setup-ai-env 10.127.222.247 \
   --nvidia-driver-installer-path /root/nvidia/NVIDIA-Linux-x86_64-570.133.07.run \
   --cuda-installer-path /root/nvidia/cuda_12.8.1_570.124.06_linux.run
 
-# 指定自定义路径
+# 指定 GPU 软共享虚拟设备数量（不指定则默认使用 HAMi）
 ocboot.py setup-ai-env 10.127.222.247 \
   --nvidia-driver-installer-path /opt/nvidia/NVIDIA-Linux-x86_64-570.172.08.run \
   --cuda-installer-path /opt/nvidia/cuda_12.8.1_570.172.08_linux.run \
@@ -71,6 +71,12 @@ ocboot.py setup-ai-env 10.127.222.247 \
 如果需要直接使用 ansible-playbook，可以通过 `-e` 参数传入变量：
 
 ```bash
+# 默认使用 HAMi
+ansible-playbook -i inventory setup-ai-env-services.yml \
+  -e nvidia_driver_installer_path=/root/nvidia/NVIDIA-Linux-x86_64-570.133.07.run \
+  -e cuda_installer_path=/root/nvidia/cuda_12.8.1_570.124.06_linux.run
+
+# 指定 NVIDIA_GPU_SHARE 虚拟设备数量
 ansible-playbook -i inventory setup-ai-env-services.yml \
   -e nvidia_driver_installer_path=/root/nvidia/NVIDIA-Linux-x86_64-570.133.07.run \
   -e cuda_installer_path=/root/nvidia/cuda_12.8.1_570.124.06_linux.run \
@@ -79,7 +85,7 @@ ansible-playbook -i inventory setup-ai-env-services.yml \
 
 ## 注意事项
 
-1. 安装过程中会自动重启系统（在安装内核包后和更新 GRUB 后）
+1. 安装完成后通常会自动重启一次以加载驱动和 GRUB；若 nouveau 仍占用 GPU，安装驱动前可能提前重启一次
 2. 确保目标主机有足够的磁盘空间
 3. 确保网络连接正常，能够下载 NVIDIA Container Toolkit
 4. 对于不同的操作系统，会自动加载相应的变量文件
@@ -111,12 +117,12 @@ scp /path/to/cuda/cuda_12.8.1_570.124.06_linux.run target_host:/root/nvidia/
 
 1. 检查操作系统支持
 2. 检查本地安装文件是否存在
-3. 安装内核头文件和开发包
-4. 清理 vfio 相关配置
-5. 安装 NVIDIA 驱动
-6. 安装 CUDA 环境
-7. 配置 GRUB（添加 nvidia-drm.modeset=1）
+3. 配置 GRUB（添加 nvidia-drm.modeset=1）
+4. 安装内核头文件和开发包
+5. 清理 vfio 相关配置
+6. 安装 NVIDIA 驱动
+7. 安装 CUDA 环境
 8. 安装 NVIDIA Container Toolkit
 9. 配置 containerd runtime
-10. 配置主机设备映射（lxcfs 由 `utils/containerd` 在本 role 之前完成）
-11. 验证安装结果
+10. 配置主机设备映射（仅在指定 `--gpu-device-virtual-number` 时生成 NVIDIA_GPU_SHARE；未指定则默认使用 HAMi。lxcfs 由 `utils/containerd` 在本 role 之前完成）
+11. 按需重启后验证安装结果

--- a/onecloud/roles/utils/ai-env/tasks/configure-grub.yml
+++ b/onecloud/roles/utils/ai-env/tasks/configure-grub.yml
@@ -16,13 +16,7 @@
   include_tasks: "configure-grub-{{ ansible_os_family }}.yml"
   when: grub_check.rc != 0
 
-- name: Reboot system after grub update
-  reboot:
-    msg: "Reboot initiated by Ansible after adding nvidia-drm.modeset=1 and updating grub"
-    connect_timeout: 5
-    reboot_timeout: 600
-    pre_reboot_delay: 0
-    post_reboot_delay: 30
-    test_command: whoami
-  become: true
+- name: Mark reboot required after GRUB modeset update
+  set_fact:
+    ai_env_reboot_required: true
   when: grub_check.rc != 0

--- a/onecloud/roles/utils/ai-env/tasks/configure-host.yml
+++ b/onecloud/roles/utils/ai-env/tasks/configure-host.yml
@@ -1,23 +1,35 @@
-- name: Discover NVIDIA renderD devices (vendor 0x10de)
-  shell: |
-    for d in /sys/class/drm/renderD*; do
-      [ -e "$d/device/vendor" ] && grep -qi "10de" "$d/device/vendor" 2>/dev/null && basename "$d"
-    done | sort -V
-  register: nvidia_render_discovery
-  changed_when: false
-  become: true
+- name: Configure NVIDIA_GPU_SHARE virtual devices
+  when: gpu_device_virtual_number is defined and gpu_device_virtual_number | int > 0
+  block:
+    - name: Discover NVIDIA renderD devices (vendor 0x10de)
+      shell: |
+        for d in /sys/class/drm/renderD*; do
+          [ -e "$d/device/vendor" ] && grep -qi "10de" "$d/device/vendor" 2>/dev/null && basename "$d"
+        done | sort -V
+      register: nvidia_render_discovery
+      changed_when: false
+      become: true
 
-- name: Set NVIDIA render device paths for template
-  set_fact:
-    nvidia_render_devices: "{{ nvidia_render_discovery.stdout_lines | default([]) | map('regex_replace', '^', '/dev/dri/') | list }}"
-  become: true
+    - name: Set NVIDIA render device paths for template
+      set_fact:
+        nvidia_render_devices: "{{ nvidia_render_discovery.stdout_lines | default([]) | map('regex_replace', '^', '/dev/dri/') | list }}"
+      become: true
 
-- name: Create container device configuration file
-  template:
-    src: host_container_device.yml.j2
-    dest: /etc/yunion/host_container_device.yml
-    mode: '0644'
-  become: true
+    - name: Create container device configuration file
+      template:
+        src: host_container_device.yml.j2
+        dest: /etc/yunion/host_container_device.yml
+        mode: '0644'
+      become: true
+
+    - name: Update host configuration
+      lineinfile:
+        path: /etc/yunion/host.conf
+        line: "{{ item }}"
+        state: present
+      become: true
+      loop:
+        - "container_device_config_file: /etc/yunion/host_container_device.yml"
 
 - name: Ensure hwdata directory exists
   file:
@@ -33,12 +45,3 @@
     group: root
     mode: '0644'
   become: true
-
-- name: Update host configuration
-  lineinfile:
-    path: /etc/yunion/host.conf
-    line: "{{ item }}"
-    state: present
-  become: true
-  loop:
-    - "container_device_config_file: /etc/yunion/host_container_device.yml"

--- a/onecloud/roles/utils/ai-env/tasks/install-cuda.yml
+++ b/onecloud/roles/utils/ai-env/tasks/install-cuda.yml
@@ -102,15 +102,4 @@
   - debug: var=cuda_install_result.stdout_lines
   - debug: var=cuda_verify_result.stdout_lines
 
-  - name: Reboot after CUDA installation
-    reboot:
-      msg: "Reboot initiated by Ansible after CUDA installation"
-      connect_timeout: 5
-      reboot_timeout: 600
-      pre_reboot_delay: 0
-      post_reboot_delay: 30
-      test_command: whoami
-    become: true
-    when: cuda_install_result is defined and cuda_install_result.changed | default(false)
-
   when: not cuda_installed | default(false)

--- a/onecloud/roles/utils/ai-env/tasks/install-nvidia-driver.yml
+++ b/onecloud/roles/utils/ai-env/tasks/install-nvidia-driver.yml
@@ -76,16 +76,42 @@
   include_tasks: "configure-grub-{{ ansible_os_family }}.yml"
   when: grub_vfio_removed.changed or grub_iommu_removed.changed
 
-- name: 重启系统
+- name: Try to unload nouveau without reboot
+  shell: rmmod nouveau
+  become: true
+  register: nouveau_rmmod
+  failed_when: false
+  changed_when: nouveau_rmmod.rc == 0
+
+- name: Check if nouveau is still loaded
+  shell: lsmod | grep -c '^nouveau' || true
+  register: nouveau_still_loaded
+  changed_when: false
+  failed_when: false
+
+- name: Reboot only if nouveau is still loaded
   reboot:
-    msg: "Reboot initiated by Ansible after vfio cleanup and grub update"
+    msg: "Reboot initiated by Ansible because nouveau is still loaded"
     connect_timeout: 5
     reboot_timeout: 600
     pre_reboot_delay: 0
     post_reboot_delay: 30
     test_command: whoami
   become: true
-  when: nouveau_blacklisted.changed or grub_vfio_removed.changed or grub_iommu_removed.changed
+  when: (nouveau_still_loaded.stdout | default('0') | trim | int) > 0
+
+- name: Record that a reboot already happened for nouveau
+  set_fact:
+    ai_env_rebooted: true
+  when: (nouveau_still_loaded.stdout | default('0') | trim | int) > 0
+
+- name: Mark reboot required after nouveau/vfio/grub changes
+  set_fact:
+    ai_env_reboot_required: true
+  when: >
+    nouveau_blacklisted.changed or
+    grub_vfio_removed.changed or
+    grub_iommu_removed.changed
 
 - name: Check if NVIDIA driver is already installed
   shell: nvidia-smi
@@ -151,7 +177,7 @@
     become: true
     args:
       executable: /bin/bash
-    register: nvidia_install_result
+    register: nvidia_install_with_src
     when: kernel_source_path | default('') != ''
 
   - name: Install NVIDIA driver without kernel source path
@@ -162,20 +188,18 @@
     become: true
     args:
       executable: /bin/bash
-    register: nvidia_install_result
+    register: nvidia_install_without_src
     when: kernel_source_path | default('') == ''
 
-  - debug: var=nvidia_install_result.stdout_lines
+  - debug: var=nvidia_install_with_src.stdout_lines
+    when: nvidia_install_with_src is changed
 
-  - name: Reboot after NVIDIA driver installation
-    reboot:
-      msg: "Reboot initiated by Ansible after NVIDIA driver installation"
-      connect_timeout: 5
-      reboot_timeout: 600
-      pre_reboot_delay: 0
-      post_reboot_delay: 30
-      test_command: whoami
-    become: true
-    when: nvidia_install_result is defined and nvidia_install_result.changed | default(false)
+  - debug: var=nvidia_install_without_src.stdout_lines
+    when: nvidia_install_without_src is changed
+
+  - name: Mark reboot required after NVIDIA driver installation
+    set_fact:
+      ai_env_reboot_required: true
+    when: nvidia_install_with_src is changed or nvidia_install_without_src is changed
 
   when: not nvidia_driver_installed | default(false)

--- a/onecloud/roles/utils/ai-env/tasks/main.yml
+++ b/onecloud/roles/utils/ai-env/tasks/main.yml
@@ -9,6 +9,10 @@
   include_tasks: check-local-files.yml
   when: nvidia_driver_installer_path is defined and cuda_installer_path is defined
 
+- name: Configure GRUB
+  include_tasks: configure-grub.yml
+  when: nvidia_driver_installer_path is defined and cuda_installer_path is defined
+
 - name: Install NVIDIA driver (if installer path provided)
   include_tasks: install-nvidia-driver.yml
   when: >
@@ -17,10 +21,6 @@
 
 - name: Install CUDA (if installer path provided)
   include_tasks: install-cuda.yml
-  when: nvidia_driver_installer_path is defined and cuda_installer_path is defined
-
-- name: Configure GRUB
-  include_tasks: configure-grub.yml
   when: nvidia_driver_installer_path is defined and cuda_installer_path is defined
 
 - name: Install Container Toolkit
@@ -33,6 +33,19 @@
 
 - name: Configure host
   include_tasks: configure-host.yml
+
+- name: Reboot after AI environment setup
+  reboot:
+    msg: "Reboot initiated by Ansible after AI environment setup"
+    connect_timeout: 5
+    reboot_timeout: 600
+    pre_reboot_delay: 0
+    post_reboot_delay: 30
+    test_command: whoami
+  become: true
+  when: >
+    (ai_env_reboot_required | default(false)) and
+    not (ai_env_rebooted | default(false))
 
 - name: Run post-tasks
   include_tasks: post-tasks.yml

--- a/onecloud/roles/utils/ai-env/templates/host_container_device.yml.j2
+++ b/onecloud/roles/utils/ai-env/templates/host_container_device.yml.j2
@@ -2,5 +2,5 @@ devices:
 {% for path in nvidia_render_devices | default([]) %}
   - path: "{{ path }}"
     type: "NVIDIA_GPU_SHARE"
-    virtual_number: {{ gpu_device_virtual_number | default(2) }}
+    virtual_number: {{ gpu_device_virtual_number }}
 {% endfor %}

--- a/onecloud/roles/utils/ai-env/vars/main.yml
+++ b/onecloud/roles/utils/ai-env/vars/main.yml
@@ -1,6 +1,6 @@
-# 默认变量
-gpu_device_virtual_number: 2
-
 # 安装包完整路径（从命令行参数传入）
 # nvidia_driver_installer_path: "/root/nvidia/NVIDIA-Linux-x86_64-570.133.07.run"
 # cuda_installer_path: "/root/nvidia/cuda_12.8.1_570.124.06_linux.run"
+
+# 仅在显式传入时生效；未指定则默认使用 HAMi
+# gpu_device_virtual_number: 2

--- a/onecloud/roles/utils/detect-os/tasks/main.yml
+++ b/onecloud/roles/utils/detect-os/tasks/main.yml
@@ -128,6 +128,27 @@
   when:
   - latest_packages is not defined
 
+- name: Detect existing container host
+  shell: |
+    if [ -f /etc/yunion/host.conf ] && grep -qE '^host_type:[[:space:]]*container([[:space:]]|$)' /etc/yunion/host.conf; then
+      exit 0
+    fi
+    if systemctl list-unit-files --type=service 2>/dev/null | grep -q '^yunion-containerd.service'; then
+      exit 0
+    fi
+    exit 1
+  register: detect_container_host
+  changed_when: false
+  failed_when: false
+  when: enable_containerd is not defined
+
+- name: Enable containerd packages on detected container host
+  set_fact:
+    enable_containerd: true
+  when:
+    - enable_containerd is not defined
+    - detect_container_host.rc | default(1) == 0
+
 - name: gather var for containerd packages
   include_vars: "../vars/containerd_packages.yml"
   when:

--- a/onecloud/setup-ai-env-services.yml
+++ b/onecloud/setup-ai-env-services.yml
@@ -8,7 +8,7 @@
     # nvidia_driver_installer_path: "/root/nvidia/NVIDIA-Linux-x86_64-570.133.07.run"
     # cuda_installer_path: "/root/nvidia/cuda_12.8.1_570.124.06_linux.run"
 
-    # GPU 设备虚拟编号（从命令行参数传入，默认值在 vars/main.yml 中）
+    # GPU 设备虚拟编号（仅在显式传入时生效；未指定则默认使用 HAMi）
     # gpu_device_virtual_number: 2
   
   roles:

--- a/run.py
+++ b/run.py
@@ -1028,10 +1028,11 @@ def main():
     if is_ai_mode:
         extra_vars = {
             'enable_ai_env': True,
-            'gpu_device_virtual_number': args.gpu_device_virtual_number,
         }
         
         # 只有在提供了 NVIDIA 相关参数时才添加这些变量
+        if args.gpu_device_virtual_number is not None:
+            extra_vars['gpu_device_virtual_number'] = args.gpu_device_virtual_number
         if args.nvidia_driver_installer_path:
             extra_vars['nvidia_driver_installer_path'] = args.nvidia_driver_installer_path
         if args.cuda_installer_path:


### PR DESCRIPTION
省略 --gpu-device-virtual-number 时不再生成 NVIDIA_GPU_SHARE； 并将 GRUB/驱动相关重启合并到安装末尾，仅在 nouveau 仍占用时提前重启。