### PR TITLE
feat(setup-container-env): 支持 --nvidia-runtime 仅配置 NVIDIA runtime

### DIFF
--- a/lib/setup_container_env.py
+++ b/lib/setup_container_env.py
@@ -1,9 +1,47 @@
 # encoding: utf-8
 from __future__ import unicode_literals
 
-from .service import Service
+from .service import BaseService, NodesConfig
+from .parser import inject_ssh_hosts_options, help_d
+
+
+class ContainerEnvService(BaseService):
+
+    def __init__(self, subparsers, action):
+        super(ContainerEnvService, self).__init__(
+            subparsers, action, "%s services of hosts" % action)
+
+    def inject_options(self, parser):
+        inject_ssh_hosts_options(parser)
+        parser.add_argument("--nvidia-runtime",
+                            dest="nvidia_runtime",
+                            action="store_true",
+                            default=False,
+                            help="Assume NVIDIA driver is already installed; install NVIDIA Container Toolkit if nvidia-ctk is missing, and configure containerd nvidia runtime only (do not install driver/CUDA)")
+        parser.add_argument("--gpu-device-virtual-number",
+                            dest="gpu_device_virtual_number",
+                            type=int,
+                            default=None,
+                            help=help_d("Virtual number for NVIDIA GPU share device. Requires --nvidia-runtime. If omitted, GPUs use HAMi by default"))
+
+    def do_action(self, args):
+        if args.gpu_device_virtual_number is not None and not args.nvidia_runtime:
+            raise ValueError("--gpu-device-virtual-number requires --nvidia-runtime")
+
+        vars = {}
+        if args.nvidia_runtime:
+            vars['nvidia_runtime_only'] = True
+        if args.gpu_device_virtual_number is not None:
+            vars['gpu_device_virtual_number'] = args.gpu_device_virtual_number
+        if args.ssh_private_file:
+            vars['ansible_ssh_private_key_file'] = args.ssh_private_file
+
+        config = NodesConfig(args.target_node_hosts,
+                             args.ssh_user,
+                             args.ssh_private_file,
+                             args.ssh_port)
+        return config.run(self.action, vars=vars or None)
 
 
 def add_command(subparsers):
-    Service(subparsers, 'setup-container-env')
-
+    ContainerEnvService(subparsers, 'setup-container-env')

--- a/onecloud/roles/utils/ai-env/tasks/check-gpu-and-driver.yml
+++ b/onecloud/roles/utils/ai-env/tasks/check-gpu-and-driver.yml
@@ -58,7 +58,7 @@
 
 - name: Fail when driver not installed and no installer path provided
   fail:
-    msg: "未检测到已安装的 NVIDIA 驱动，且未提供 --nvidia-driver-installer-path。请先安装驱动或通过参数指定安装包路径。"
+    msg: "{{ '未检测到已安装的 NVIDIA 驱动。--nvidia-runtime 要求目标机已安装驱动（nvidia-smi 可用），或改用 setup-ai-env 并指定安装包路径。' if (nvidia_runtime_only | default(false)) else '未检测到已安装的 NVIDIA 驱动，且未提供 --nvidia-driver-installer-path。请先安装驱动或通过参数指定安装包路径。' }}"
   when: not nvidia_driver_installed | default(false) and nvidia_driver_installer_path is not defined
 
 - name: Fail when CUDA not installed and no installer path provided

--- a/onecloud/roles/utils/ai-env/tasks/main.yml
+++ b/onecloud/roles/utils/ai-env/tasks/main.yml
@@ -3,33 +3,47 @@
 
 - name: Check NVIDIA GPU and driver/CUDA status on target host
   include_tasks: check-gpu-and-driver.yml
-  when: nvidia_driver_installer_path is defined
+  when: nvidia_driver_installer_path is defined or (nvidia_runtime_only | default(false))
 
 - name: Check local installation files
   include_tasks: check-local-files.yml
-  when: nvidia_driver_installer_path is defined and cuda_installer_path is defined
+  when: >
+    nvidia_driver_installer_path is defined and
+    cuda_installer_path is defined and
+    not (nvidia_runtime_only | default(false))
 
 - name: Configure GRUB
   include_tasks: configure-grub.yml
-  when: nvidia_driver_installer_path is defined and cuda_installer_path is defined
+  when: >
+    nvidia_driver_installer_path is defined and
+    cuda_installer_path is defined and
+    not (nvidia_runtime_only | default(false))
 
 - name: Install NVIDIA driver (if installer path provided)
   include_tasks: install-nvidia-driver.yml
   when: >
     nvidia_driver_installer_path is defined and
+    not (nvidia_runtime_only | default(false)) and
     not (ai_env_fully_ready | default(false))
 
 - name: Install CUDA (if installer path provided)
   include_tasks: install-cuda.yml
-  when: nvidia_driver_installer_path is defined and cuda_installer_path is defined
+  when: >
+    nvidia_driver_installer_path is defined and
+    cuda_installer_path is defined and
+    not (nvidia_runtime_only | default(false))
 
 - name: Install Container Toolkit
   include_tasks: install-container-toolkit.yml
-  when: nvidia_driver_installer_path is defined and cuda_installer_path is defined
+  when: >
+    (nvidia_driver_installer_path is defined and cuda_installer_path is defined) or
+    (nvidia_runtime_only | default(false))
 
 - name: Configure containerd
   include_tasks: configure-containerd.yml
-  when: nvidia_driver_installer_path is defined and cuda_installer_path is defined
+  when: >
+    (nvidia_driver_installer_path is defined and cuda_installer_path is defined) or
+    (nvidia_runtime_only | default(false))
 
 - name: Configure host
   include_tasks: configure-host.yml
@@ -45,8 +59,11 @@
   become: true
   when: >
     (ai_env_reboot_required | default(false)) and
-    not (ai_env_rebooted | default(false))
+    not (ai_env_rebooted | default(false)) and
+    not (nvidia_runtime_only | default(false))
 
 - name: Run post-tasks
   include_tasks: post-tasks.yml
-  when: nvidia_driver_installer_path is defined and cuda_installer_path is defined
+  when: >
+    (nvidia_driver_installer_path is defined and cuda_installer_path is defined) or
+    (nvidia_runtime_only | default(false))

--- a/onecloud/setup-container-env-services.yml
+++ b/onecloud/setup-container-env-services.yml
@@ -1,3 +1,4 @@
 - hosts: all
   roles:
     - { role: utils/containerd }
+    - { role: utils/ai-env, when: nvidia_runtime_only | default(false) }


### PR DESCRIPTION
在驱动已安装时跳过驱动/CUDA 安装，只安装 Container Toolkit 并配置 containerd nvidia runtime。